### PR TITLE
add contributor agreement

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@ This repo contains the technical reference manual for the Bonsai visual programm
 
 1. Fork the "develop" branch of this repository.
 2. Download and install the latest stable version of [DocFx](https://dotnet.github.io/docfx/index.html)(currently 2.59).
-3. Use the command `docfx docfx.json --serve` to generate a local preview of the documentation website.
+3. In a Windows Powershell, use the command `docfx docfx.json --serve` to generate a local preview of the documentation website.
 4. When you are ready to have your contribution reviewed, commit your edits to a descriptively named branch of your fork of the repo and create a PR to merge your fork with the "develop" branch of this original repo.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,132 @@
 
 This repo contains the technical reference manual for the Bonsai visual programming language, in addition to articles and examples that document the collective knowledge of the Bonsai user community.
 
-## Would you like to contribute to this repo?
+# Would you like to contribute to this repo?
+
+## Bonsai Project Contributor Agreement
+
+This contributor agreement was inspired by the [Bonsai Project Contributor Agreement](https://Bonsaiproject.org/wiki/Legal:Bonsai_Project_Contributor_Agreement), which served as a template for the agreement. 
+
+To get started as a contributor to the Bonsai Documentation, please first read through the Bonsai Project Contributor Agreement below.
+
+### Overview
+
+The only purpose of the Bonsai Project Contributor Agreement (BPCA) is to ensure that Bonsai has default permission to use your contributions under a permissive free license (either MIT for software or CC BY-SA for content). You may contribute under any other acceptable Bonsai license, the BPCA simply sets a default if no license is specified.
+
+Nothing in the BPCA takes anything away from you. You retain ownership of your contributions.
+
+If you have any questions about the BPCA, please email contact@NeuroGEARS.org.
+
+### BPCA Text
+
+The Bonsai Project Contributor Agreement
+Version 2022-03-10
+
+**Goal**
+----
+We require that contributors to Bonsai (as defined below) agree to this Bonsai Project Contributor Agreement (BPCA) to ensure that contributions to Bonsai have acceptable licensing terms. 
+
+**Non-Goals**
+----
+The BPCA is *not* a copyright assignment agreement. 
+
+The BPCA does *not* somehow supersede the existing licensing terms that apply to Bonsai contributions. There are two important subpoints here.  First, the BPCA does not apply to upstream code (or other material) that you didn't write; indeed, it would be preposterous for it to attempt to do so.  Note the narrow way in which we have defined capital-c "Contribution".  Second, the main provision of the BPCA specifies that a default license will apply to code that you wrote, but only to the extent that you have not bothered to put an explicit license on it. Therefore, the BPCA is *not* some sort of special permissive license granted to any party, despite the explicit choice of a more restrictive license by you or by upstream developers.
+
+**Terms**
+-----
+
+0.  Definitions.
+
+"Acceptable License For Bonsai" means a license selected from the appropriate categorical sublist of the full list of acceptable licenses for Bonsai, currently located at [NEED LINK TO LIST OF ACCEPTABLE LICENSES], as that list may be revised from time to time by the **Bonsai Council** [PLACEHOLDER] [WHO IS THE GOVERNING BODY OF BONSAI?].  "Acceptable Licenses For Bonsai" means that full list.
+
+"CC-BY-SA" means the Creative Commons Attribution-ShareAlike 4.0 International license, as published at <https://creativecommons.org/licenses/by-sa/4.0/legalcode>.
+
+"Code" means (i) software code, (ii) any other functional material whose principal purpose is to control or facilitate the building of packages, such as an RPM spec file, (iii) font files, and (iv) other kinds of copyrightable material that the **Bonsai Council** [PLACEHOLDER] has classified as "code" rather than "content".
+
+"Content" means any copyrightable material that is not Code, such as, without limitation, (i) non-functional data sets, (ii) documentation, (iii) wiki edits, (iv) video files, (v) graphic image files, (vi) help files, and (vii) other kinds of copyrightable material that the **Bonsai Council** [PLACEHOLDER] has classified as "content" rather than "code".
+
+"Contribution" means a Work that You created, excluding any portion that was created by someone else.  (For example, if You Submit a package to Bonsai, the spec file You write may be a Contribution, but all the upstream code in the associated SRPM that You did not write is not a Contribution for purposes of this FPCA.)  A Contribution consists either of Code or of Content.
+
+"Current Default License", with respect to a Contribution, means (i) if the Contribution is Code, the MIT License, and (ii) if the Contribution is Content, CC-BY-SA.
+
+"Bonsai" means the community project led by the **Bonsai Council** [PLACEHOLDER] <https://Bonsaiproject.org/wiki/Council> **[NEED TO UPDATE THIS LINK]**.
+
+"Bonsai Community" means (i) all Bonsai users, (ii) Bonsai developers, and (iii) all persons receiving Contributions directly or indirectly from or through Bonsai.
+
+"Licensed" means covered by explicit licensing terms that are conspicuous and readily discernible to recipients.
+
+"MIT License" means the license identified as "Modern Style with sublicense" at <https://Bonsaiproject.org/wiki/Licensing:MIT#Modern_Style_with_sublicense> **[NEED TO UPDATE THIS LINK]**.
+
+"Submit" means to use some mode of digital communication (for example, without limitation, mailing lists, bug tracking systems, and source code version control systems administered by Bonsai) to voluntarily provide a Contribution to Bonsai.
+
+"Unlicensed" means not Licensed.
+
+"Work" means a copyrightable work of authorship. A Work may be a portion of a larger Work, and a Work may be a modification of or addition to another Work.
+
+"You" means the individual accepting this instance of the FPCA.
+
+
+1. Copyright Permission Required for All Contributions.
+
+If You are not the copyright holder of a given Contribution that You wish to Submit to Bonsai (for example, if Your employer or university holds copyright in it), it is Your responsibility to first obtain authorization from the copyright holder to Submit the Contribution under the terms of this FPCA on behalf of, or otherwise with the permission of, that copyright holder.  One form of such authorization is for the copyright holder to place, or permit You to place, an Acceptable License For Bonsai on the Contribution.
+
+
+2.  Licensed Contributions.
+
+If Your Contribution is Licensed, Your Contribution will be governed by the terms under which it has been licensed.
+
+
+3.  Default Licensing of Unlicensed Contributions.
+
+If You Submit an Unlicensed Contribution to Bonsai, the license to the Bonsai Community for that Contribution shall be the Current Default License.
+
+The **Bonsai Council** [PLACEHOLDER] may, by public announcement, subsequently designate an additional or alternative default license for a given category of Contribution (a "Later Default License"). A Later Default License shall be chosen from the appropriate categorical sublist of Acceptable Licenses For Bonsai.
+
+Once a Later Default License has been designated, Your Unlicensed Contribution shall also be licensed to the Bonsai Community under that Later Default License.  Such designation shall not affect the continuing applicability of the Current Default License to Your Contribution.
+
+You consent to having Bonsai provide reasonable notice of Your licensing of Your Contribution under the Current Default License (and, if applicable, a Later Default License) in a manner determined by Bonsai.
+
+4.  Public Domain United States Government Works. **[NOT SURE IF WE NEED THIS SECTION; IF WE DO, DO WE NEED TO SAY SOMETHING ABOUT UK GOV?]**
+
+Sections 1 through 3 of this FPCA do not apply to any Contribution to the extent that it is a work of the United States Government for which copyright is unavailable under 17 U.S.C. 105.
+ 
+5.  Acceptance.
+
+You must signify Your assent to the terms of this FPCA through specific electronic means established by Bonsai (such as by click-through acceptance means).
+
+You may also, at Your option, and without eliminating the requirement set forth in the preceding paragraph, send a copy of this FPCA, bearing Your written signature indicating Your acceptance of its terms, by email to **legal@Bonsaiproject.org [PLACEHOLDER]**, by fax to **+1 919 754 3704 [PLACEHOLDER]**, or by postal mail to:
+
+  Bonsai Legal
+  c/o Red Hat, Inc.
+  100 East Davie Street
+  Raleigh, NC 27601
+  USA
+  **[PLACEHOLDER]**
+
+### FAQ
+
+**Q. What is the purpose of the BPCA?**
+A. The BPCA exists for one main reason: to ensure that contributions to Bonsai have acceptable licensing terms. 
+
+**Q. If I agree to the BPCA, am I assigning copyright to Bonsai, Goncalo Lopes, or NeuroGEARS?**
+A. No. The BPCA is not a copyright assignment agreement. 
+
+**Q. Does this mean that Bonsai will always relicense my contributions from $MY_LICENSE to MIT?**
+A. No. If you put a Free license on your contribution, we will use it under the terms of that license. If you put it under a non-Free license, we won't use it at all. Only unlicensed contributions where the copyright holder is the Bonsai contributor qualify for the "default licensing" clause. 
+
+**Q. Do I need to physically sign the BPCA?**
+A. No. We require that all contributors agree to it digitally, through **[WE NEED TO DECIDE ON A PROCESS FOR THIS]**. If you wish to additionally sign a physical copy and send it to us, the BPCA describes how to do this, but it is **NOT** required. 
+
+**Q. Are all Bonsai users/distributors required to agree to the BPCA?**
+A. No. Only Bonsai contributors will be required to agree to the BPCA. However, if you want to agree to it, you always can :)
+
+**Q. The BPCA defines "default licenses" of MIT for code, and Creative Commons Attribution-ShareAlike 4.0 for content, why not $OTHER_LICENSE?**
+A. These licenses were chosen because of their widespread use and compatibility with most other Free licenses.
+
+**Q. I have a question/suggestion/flame about the BPCA that is not covered here, where should I send it to?**
+A. If you want to discuss it in public, please subscribe to the **[BONSAI FORUM? DISCORD?]** and post your thoughts there. If you do not wish to discuss it in public, feel free to send it via email to **legal@bonsaiproject.org [PLACEHOLDER]**.
+
+## Step-by-step guide to getting started as a contributor
 
 1. Fork the "develop" branch of this repository.
 2. Download and install the latest stable version of [DocFx](https://dotnet.github.io/docfx/index.html)(currently 2.59).

--- a/README.md
+++ b/README.md
@@ -202,25 +202,25 @@ USA
 ``` 
 ### FAQ
 
-**Q. What is the purpose of the BPCA?**
+**Q. What is the purpose of the BPCA?**  
 A. The BPCA exists for one main reason: to ensure that contributions to Bonsai have acceptable licensing terms. 
 
-**Q. If I agree to the BPCA, am I assigning copyright to Bonsai, Goncalo Lopes, or NeuroGEARS?**
+**Q. If I agree to the BPCA, am I assigning copyright to Bonsai, Goncalo Lopes, or NeuroGEARS?**  
 A. No. The BPCA is not a copyright assignment agreement. 
 
-**Q. Does this mean that Bonsai will always relicense my contributions from $MY_LICENSE to MIT?**
+**Q. Does this mean that Bonsai will always relicense my contributions from $MY_LICENSE to MIT?**  
 A. No. If you put a Free license on your contribution, we will use it under the terms of that license. If you put it under a non-Free license, we won't use it at all. Only unlicensed contributions where the copyright holder is the Bonsai contributor qualify for the "default licensing" clause. 
 
-**Q. Do I need to physically sign the BPCA?**
+**Q. Do I need to physically sign the BPCA?**  
 A. No. We require that all contributors agree to it digitally, through **[WE NEED TO DECIDE ON A PROCESS FOR THIS]**. If you wish to additionally sign a physical copy and send it to us, the BPCA describes how to do this, but it is **NOT** required. 
 
-**Q. Are all Bonsai users/distributors required to agree to the BPCA?**
+**Q. Are all Bonsai users/distributors required to agree to the BPCA?**  
 A. No. Only Bonsai contributors will be required to agree to the BPCA. However, if you want to agree to it, you always can :)
 
-**Q. The BPCA defines "default licenses" of MIT for code, and Creative Commons Attribution-ShareAlike 4.0 for content, why not $OTHER_LICENSE?**
+**Q. The BPCA defines "default licenses" of MIT for code, and Creative Commons Attribution-ShareAlike 4.0 for content, why not $OTHER_LICENSE?**  
 A. These licenses were chosen because of their widespread use and compatibility with most other Free licenses.
 
-**Q. I have a question/suggestion/flame about the BPCA that is not covered here, where should I send it to?**
+**Q. I have a question/suggestion/flame about the BPCA that is not covered here, where should I send it to?**  
 A. If you want to discuss it in public, please subscribe to the **[BONSAI FORUM? DISCORD?]** and post your thoughts there. If you do not wish to discuss it in public, feel free to send it via email to **legal@bonsaiproject.org [PLACEHOLDER]**.
 
 ## Step-by-step guide to getting started as a contributor

--- a/README.md
+++ b/README.md
@@ -19,91 +19,185 @@ Nothing in the BPCA takes anything away from you. You retain ownership of your c
 If you have any questions about the BPCA, please email contact@NeuroGEARS.org.
 
 ```
-    ### BPCA Text
+### BPCA Text
 
-    The Bonsai Project Contributor Agreement
-    Version 2022-03-10
+The Bonsai Project Contributor Agreement
+Version 2022-03-10
 
-    #### Goal
+#### Goal
 
-    We require that contributors to Bonsai (as defined below) agree to this Bonsai Project Contributor Agreement (BPCA) to ensure that contributions to Bonsai have acceptable licensing terms. 
+We require that contributors to Bonsai (as defined below) 
+agree to this Bonsai Project Contributor Agreement (BPCA) 
+to ensure that contributions to Bonsai have acceptable 
+licensing terms. 
 
-    #### Non-Goals
+#### Non-Goals
 
-    The BPCA is *not* a copyright assignment agreement. 
+The BPCA is *not* a copyright assignment agreement. 
 
-    The BPCA does *not* somehow supersede the existing licensing terms that apply to Bonsai contributions. There are two important subpoints here.  First, the BPCA does not apply to upstream code (or other material) that you didn't write; indeed, it would be preposterous for it to attempt to do so.  Note the narrow way in which we have defined capital-c "Contribution".  Second, the main provision of the BPCA specifies that a default license will apply to code that you wrote, but only to the extent that you have not bothered to put an explicit license on it. Therefore, the BPCA is *not* some sort of special permissive license granted to any party, despite the explicit choice of a more restrictive license by you or by upstream developers.
+The BPCA does *not* somehow supersede the existing 
+licensing terms that apply to Bonsai contributions. There 
+are two important subpoints here.  First, the BPCA does not 
+apply to upstream code (or other material) that you didn't 
+write; indeed, it would be preposterous for it to attempt 
+to do so.  Note the narrow way in which we have defined 
+capital-c "Contribution".  Second, the main provision of 
+the BPCA specifies that a default license will apply to 
+code that you wrote, but only to the extent that you have 
+not bothered to put an explicit license on it. Therefore, 
+the BPCA is *not* some sort of special permissive license 
+granted to any party, despite the explicit choice of a more 
+restrictive license by you or by upstream developers.
 
-    #### Terms
-
-
-    1.  Definitions.
-
-    "Acceptable License For Bonsai" means a license selected from the appropriate categorical sublist of the full list of acceptable licenses for Bonsai, currently located at [NEED LINK TO LIST OF ACCEPTABLE LICENSES], as that list may be revised from time to time by the **Bonsai Council** [PLACEHOLDER] [WHO IS THE GOVERNING BODY OF BONSAI?].  "Acceptable Licenses For Bonsai" means that full list.
-
-    "CC-BY-SA" means the Creative Commons Attribution-ShareAlike 4.0 International license, as published at <https://creativecommons.org/licenses/by-sa/4.0/legalcode>.
-
-    "Code" means (i) software code, (ii) any other functional material whose principal purpose is to control or facilitate the building of packages, such as an RPM spec file, (iii) font files, and (iv) other kinds of copyrightable material that the **Bonsai Council** [PLACEHOLDER] has classified as "code" rather than "content".
-
-    "Content" means any copyrightable material that is not Code, such as, without limitation, (i) non-functional data sets, (ii) documentation, (iii) wiki edits, (iv) video files, (v) graphic image files, (vi) help files, and (vii) other kinds of copyrightable material that the **Bonsai Council** [PLACEHOLDER] has classified as "content" rather than "code".
-
-    "Contribution" means a Work that You created, excluding any portion that was created by someone else.  (For example, if You Submit a package to Bonsai, the spec file You write may be a Contribution, but all the upstream code in the associated SRPM that You did not write is not a Contribution for purposes of this FPCA.)  A Contribution consists either of Code or of Content.
-
-    "Current Default License", with respect to a Contribution, means (i) if the Contribution is Code, the MIT License, and (ii) if the Contribution is Content, CC-BY-SA.
-
-    "Bonsai" means the community project led by the **Bonsai Council** [PLACEHOLDER] <https://Bonsaiproject.org/wiki/Council> **[NEED TO UPDATE THIS LINK]**.
-
-    "Bonsai Community" means (i) all Bonsai users, (ii) Bonsai developers, and (iii) all persons receiving Contributions directly or indirectly from or through Bonsai.
-
-    "Licensed" means covered by explicit licensing terms that are conspicuous and readily discernible to recipients.
-
-    "MIT License" means the license identified as "Modern Style with sublicense" at <https://Bonsaiproject.org/wiki/Licensing:MIT#Modern_Style_with_sublicense> **[NEED TO UPDATE THIS LINK]**.
-
-    "Submit" means to use some mode of digital communication (for example, without limitation, mailing lists, bug tracking systems, and source code version control systems administered by Bonsai) to voluntarily provide a Contribution to Bonsai.
-
-    "Unlicensed" means not Licensed.
-
-    "Work" means a copyrightable work of authorship. A Work may be a portion of a larger Work, and a Work may be a modification of or addition to another Work.
-
-    "You" means the individual accepting this instance of the FPCA.
+#### Terms
 
 
-    1. Copyright Permission Required for All Contributions.
+1.  Definitions.
 
-    If You are not the copyright holder of a given Contribution that You wish to Submit to Bonsai (for example, if Your employer or university holds copyright in it), it is Your responsibility to first obtain authorization from the copyright holder to Submit the Contribution under the terms of this FPCA on behalf of, or otherwise with the permission of, that copyright holder.  One form of such authorization is for the copyright holder to place, or permit You to place, an Acceptable License For Bonsai on the Contribution.
+"Acceptable License For Bonsai" means a license selected 
+from the appropriate categorical sublist of the full list 
+of acceptable licenses for Bonsai, currently located at 
+[NEED LINK TO LIST OF ACCEPTABLE LICENSES], as that list 
+may be revised from time to time by the **Bonsai Council** 
+[PLACEHOLDER] [WHO IS THE GOVERNING BODY OF BONSAI?].  
+"Acceptable Licenses For Bonsai" means that full list.
+
+"CC-BY-SA" means the Creative Commons Attribution-
+ShareAlike 4.0 International license, as published at 
+<https://creativecommons.org/licenses/by-sa/4.0/legalcode>.
+
+"Code" means (i) software code, (ii) any other functional  
+material whose principal purpose is to control or 
+facilitate the building of packages, such as an RPM spec 
+file, (iii) font files, and (iv) other kinds of 
+copyrightable material that the **Bonsai Council** 
+[PLACEHOLDER] has classified as "code" rather than 
+"content".
+
+"Content" means any copyrightable material that is not 
+Code, such as, without limitation, (i) non-functional data 
+sets, (ii) documentation, (iii) wiki edits, (iv) video 
+files, (v) graphic image files, (vi) help files, and (vii) 
+other kinds of copyrightable material that the **Bonsai 
+Council** [PLACEHOLDER] has classified as "content" rather 
+than "code".
+
+"Contribution" means a Work that You created, excluding any 
+portion that was created by someone else.  (For example, if 
+You Submit a package to Bonsai, the spec file You write may 
+be a Contribution, but all the upstream code in the 
+associated SRPM that You did not write is not a 
+Contribution for purposes of this FPCA.)  A Contribution 
+consists either of Code or of Content.
+
+"Current Default License", with respect to a Contribution, 
+means (i) if the Contribution is Code, the MIT License, 
+and (ii) if the Contribution is Content, CC-BY-SA.
+
+"Bonsai" means the community project led by the **Bonsai 
+Council** [PLACEHOLDER] 
+<https://Bonsaiproject.org/wiki/Council> **[NEED TO UPDATE 
+THIS LINK]**.
+
+"Bonsai Community" means (i) all Bonsai users, (ii) Bonsai 
+developers, and (iii) all persons receiving Contributions 
+directly or indirectly from or through Bonsai.
+
+"Licensed" means covered by explicit licensing terms that 
+are conspicuous and readily discernible to recipients.
+
+"MIT License" means the license identified as "Modern Style 
+with sublicense" at 
+<https://Bonsaiproject.org/wiki/Licensing:MIT#Modern_Style_with_sublicense> 
+**[NEED TO UPDATE THIS LINK]**.
+
+"Submit" means to use some mode of digital communication 
+(for example, without limitation, mailing lists, bug 
+tracking systems, and source code version control systems 
+administered by Bonsai) to voluntarily provide a 
+Contribution to Bonsai.
+
+"Unlicensed" means not Licensed.
+
+"Work" means a copyrightable work of authorship. A Work may 
+be a portion of a larger Work, and a Work may be a 
+modification of or addition to another Work.
+
+"You" means the individual accepting this instance of the 
+FPCA.
 
 
-    1.  Licensed Contributions.
+1. Copyright Permission Required for All Contributions.
 
-    If Your Contribution is Licensed, Your Contribution will be governed by the terms under which it has been licensed.
+If You are not the copyright holder of a given Contribution 
+that You wish to Submit to Bonsai (for example, if Your 
+employer or university holds copyright in it), it is Your 
+responsibility to first obtain authorization from the 
+copyright holder to Submit the Contribution under the terms 
+of this FPCA on behalf of, or otherwise with the permission 
+of, that copyright holder.  One form of such authorization 
+is for the copyright holder to place, or permit You to 
+place, an Acceptable License For Bonsai on the Contribution.
 
 
-    1.  Default Licensing of Unlicensed Contributions.
+1.  Licensed Contributions.
 
-    If You Submit an Unlicensed Contribution to Bonsai, the license to the Bonsai Community for that Contribution shall be the Current Default License.
+If Your Contribution is Licensed, Your Contribution will be 
+governed by the terms under which it has been licensed.
 
-    The **Bonsai Council** [PLACEHOLDER] may, by public announcement, subsequently designate an additional or alternative default license for a given category of Contribution (a "Later Default License"). A Later Default License shall be chosen from the appropriate categorical sublist of Acceptable Licenses For Bonsai.
 
-    Once a Later Default License has been designated, Your Unlicensed Contribution shall also be licensed to the Bonsai Community under that Later Default License.  Such designation shall not affect the continuing applicability of the Current Default License to Your Contribution.
+1.  Default Licensing of Unlicensed Contributions.
 
-    You consent to having Bonsai provide reasonable notice of Your licensing of Your Contribution under the Current Default License (and, if applicable, a Later Default License) in a manner determined by Bonsai.
+If You Submit an Unlicensed Contribution to Bonsai, the 
+license to the Bonsai Community for that Contribution shall 
+be the Current Default License.
 
-    1.  Public Domain United States Government Works. **[NOT SURE IF WE NEED THIS SECTION; IF WE DO, DO WE NEED TO SAY SOMETHING ABOUT UK GOV?]**
+The **Bonsai Council** [PLACEHOLDER] may, by public 
+announcement, subsequently designate an additional or 
+alternative default license for a given category of 
+Contribution (a "Later Default License"). A Later Default 
+License shall be chosen from the appropriate categorical 
+sublist of Acceptable Licenses For Bonsai.
 
-    Sections 1 through 3 of this FPCA do not apply to any Contribution to the extent that it is a work of the United States Government for which copyright is unavailable under 17 U.S.C. 105.
-    
-    1.  Acceptance.
+Once a Later Default License has been designated, Your 
+Unlicensed Contribution shall also be licensed to the 
+Bonsai Community under that Later Default License.  Such 
+designation shall not affect the continuing applicability 
+of the Current Default License to Your Contribution.
 
-    You must signify Your assent to the terms of this FPCA through specific electronic means established by Bonsai (such as by click-through acceptance means).
+You consent to having Bonsai provide reasonable notice of 
+Your licensing of Your Contribution under the Current 
+Default License (and, if applicable, a Later Default 
+License) in a manner determined by Bonsai.
 
-    You may also, at Your option, and without eliminating the requirement set forth in the preceding paragraph, send a copy of this FPCA, bearing Your written signature indicating Your acceptance of its terms, by email to **legal@Bonsaiproject.org [PLACEHOLDER]**, by fax to **+1 919 754 3704 [PLACEHOLDER]**, or by postal mail to:
+1.  Public Domain United States Government Works. **[NOT 
+SURE IF WE NEED THIS SECTION; IF WE DO, DO WE NEED TO SAY 
+SOMETHING ABOUT UK GOV?]**
 
-    Bonsai Legal  
-    c/o Red Hat, Inc.  
-    100 East Davie Street  
-    Raleigh, NC 27601  
-    USA  
-    **[PLACEHOLDER]**  
+Sections 1 through 3 of this FPCA do not apply to any 
+Contribution to the extent that it is a work of the United 
+States Government for which copyright is unavailable under 
+17 U.S.C. 105.
+
+1.  Acceptance.
+
+You must signify Your assent to the terms of this FPCA 
+through specific electronic means established by Bonsai 
+(such as by click-through acceptance means).
+
+You may also, at Your option, and without eliminating the 
+requirement set forth in the preceding paragraph, send a 
+copy of this FPCA, bearing Your written signature 
+indicating Your acceptance of its terms, by email to 
+**legal@Bonsaiproject.org [PLACEHOLDER]**, by fax to 
+**+1 919 754 3704 [PLACEHOLDER]**, or by postal mail to:
+
+Bonsai Legal  
+c/o Red Hat, Inc.  
+100 East Davie Street  
+Raleigh, NC 27601  
+USA  
+**[PLACEHOLDER]**  
 
 ``` 
 ### FAQ

--- a/README.md
+++ b/README.md
@@ -18,92 +18,94 @@ Nothing in the BPCA takes anything away from you. You retain ownership of your c
 
 If you have any questions about the BPCA, please email contact@NeuroGEARS.org.
 
-### BPCA Text
+```
+    ### BPCA Text
 
-The Bonsai Project Contributor Agreement
-Version 2022-03-10
+    The Bonsai Project Contributor Agreement
+    Version 2022-03-10
 
-**Goal**
-----
-We require that contributors to Bonsai (as defined below) agree to this Bonsai Project Contributor Agreement (BPCA) to ensure that contributions to Bonsai have acceptable licensing terms. 
+    #### Goal
 
-**Non-Goals**
-----
-The BPCA is *not* a copyright assignment agreement. 
+    We require that contributors to Bonsai (as defined below) agree to this Bonsai Project Contributor Agreement (BPCA) to ensure that contributions to Bonsai have acceptable licensing terms. 
 
-The BPCA does *not* somehow supersede the existing licensing terms that apply to Bonsai contributions. There are two important subpoints here.  First, the BPCA does not apply to upstream code (or other material) that you didn't write; indeed, it would be preposterous for it to attempt to do so.  Note the narrow way in which we have defined capital-c "Contribution".  Second, the main provision of the BPCA specifies that a default license will apply to code that you wrote, but only to the extent that you have not bothered to put an explicit license on it. Therefore, the BPCA is *not* some sort of special permissive license granted to any party, despite the explicit choice of a more restrictive license by you or by upstream developers.
+    #### Non-Goals
 
-**Terms**
------
+    The BPCA is *not* a copyright assignment agreement. 
 
-0.  Definitions.
+    The BPCA does *not* somehow supersede the existing licensing terms that apply to Bonsai contributions. There are two important subpoints here.  First, the BPCA does not apply to upstream code (or other material) that you didn't write; indeed, it would be preposterous for it to attempt to do so.  Note the narrow way in which we have defined capital-c "Contribution".  Second, the main provision of the BPCA specifies that a default license will apply to code that you wrote, but only to the extent that you have not bothered to put an explicit license on it. Therefore, the BPCA is *not* some sort of special permissive license granted to any party, despite the explicit choice of a more restrictive license by you or by upstream developers.
 
-"Acceptable License For Bonsai" means a license selected from the appropriate categorical sublist of the full list of acceptable licenses for Bonsai, currently located at [NEED LINK TO LIST OF ACCEPTABLE LICENSES], as that list may be revised from time to time by the **Bonsai Council** [PLACEHOLDER] [WHO IS THE GOVERNING BODY OF BONSAI?].  "Acceptable Licenses For Bonsai" means that full list.
-
-"CC-BY-SA" means the Creative Commons Attribution-ShareAlike 4.0 International license, as published at <https://creativecommons.org/licenses/by-sa/4.0/legalcode>.
-
-"Code" means (i) software code, (ii) any other functional material whose principal purpose is to control or facilitate the building of packages, such as an RPM spec file, (iii) font files, and (iv) other kinds of copyrightable material that the **Bonsai Council** [PLACEHOLDER] has classified as "code" rather than "content".
-
-"Content" means any copyrightable material that is not Code, such as, without limitation, (i) non-functional data sets, (ii) documentation, (iii) wiki edits, (iv) video files, (v) graphic image files, (vi) help files, and (vii) other kinds of copyrightable material that the **Bonsai Council** [PLACEHOLDER] has classified as "content" rather than "code".
-
-"Contribution" means a Work that You created, excluding any portion that was created by someone else.  (For example, if You Submit a package to Bonsai, the spec file You write may be a Contribution, but all the upstream code in the associated SRPM that You did not write is not a Contribution for purposes of this FPCA.)  A Contribution consists either of Code or of Content.
-
-"Current Default License", with respect to a Contribution, means (i) if the Contribution is Code, the MIT License, and (ii) if the Contribution is Content, CC-BY-SA.
-
-"Bonsai" means the community project led by the **Bonsai Council** [PLACEHOLDER] <https://Bonsaiproject.org/wiki/Council> **[NEED TO UPDATE THIS LINK]**.
-
-"Bonsai Community" means (i) all Bonsai users, (ii) Bonsai developers, and (iii) all persons receiving Contributions directly or indirectly from or through Bonsai.
-
-"Licensed" means covered by explicit licensing terms that are conspicuous and readily discernible to recipients.
-
-"MIT License" means the license identified as "Modern Style with sublicense" at <https://Bonsaiproject.org/wiki/Licensing:MIT#Modern_Style_with_sublicense> **[NEED TO UPDATE THIS LINK]**.
-
-"Submit" means to use some mode of digital communication (for example, without limitation, mailing lists, bug tracking systems, and source code version control systems administered by Bonsai) to voluntarily provide a Contribution to Bonsai.
-
-"Unlicensed" means not Licensed.
-
-"Work" means a copyrightable work of authorship. A Work may be a portion of a larger Work, and a Work may be a modification of or addition to another Work.
-
-"You" means the individual accepting this instance of the FPCA.
+    #### Terms
 
 
-1. Copyright Permission Required for All Contributions.
+    1.  Definitions.
 
-If You are not the copyright holder of a given Contribution that You wish to Submit to Bonsai (for example, if Your employer or university holds copyright in it), it is Your responsibility to first obtain authorization from the copyright holder to Submit the Contribution under the terms of this FPCA on behalf of, or otherwise with the permission of, that copyright holder.  One form of such authorization is for the copyright holder to place, or permit You to place, an Acceptable License For Bonsai on the Contribution.
+    "Acceptable License For Bonsai" means a license selected from the appropriate categorical sublist of the full list of acceptable licenses for Bonsai, currently located at [NEED LINK TO LIST OF ACCEPTABLE LICENSES], as that list may be revised from time to time by the **Bonsai Council** [PLACEHOLDER] [WHO IS THE GOVERNING BODY OF BONSAI?].  "Acceptable Licenses For Bonsai" means that full list.
+
+    "CC-BY-SA" means the Creative Commons Attribution-ShareAlike 4.0 International license, as published at <https://creativecommons.org/licenses/by-sa/4.0/legalcode>.
+
+    "Code" means (i) software code, (ii) any other functional material whose principal purpose is to control or facilitate the building of packages, such as an RPM spec file, (iii) font files, and (iv) other kinds of copyrightable material that the **Bonsai Council** [PLACEHOLDER] has classified as "code" rather than "content".
+
+    "Content" means any copyrightable material that is not Code, such as, without limitation, (i) non-functional data sets, (ii) documentation, (iii) wiki edits, (iv) video files, (v) graphic image files, (vi) help files, and (vii) other kinds of copyrightable material that the **Bonsai Council** [PLACEHOLDER] has classified as "content" rather than "code".
+
+    "Contribution" means a Work that You created, excluding any portion that was created by someone else.  (For example, if You Submit a package to Bonsai, the spec file You write may be a Contribution, but all the upstream code in the associated SRPM that You did not write is not a Contribution for purposes of this FPCA.)  A Contribution consists either of Code or of Content.
+
+    "Current Default License", with respect to a Contribution, means (i) if the Contribution is Code, the MIT License, and (ii) if the Contribution is Content, CC-BY-SA.
+
+    "Bonsai" means the community project led by the **Bonsai Council** [PLACEHOLDER] <https://Bonsaiproject.org/wiki/Council> **[NEED TO UPDATE THIS LINK]**.
+
+    "Bonsai Community" means (i) all Bonsai users, (ii) Bonsai developers, and (iii) all persons receiving Contributions directly or indirectly from or through Bonsai.
+
+    "Licensed" means covered by explicit licensing terms that are conspicuous and readily discernible to recipients.
+
+    "MIT License" means the license identified as "Modern Style with sublicense" at <https://Bonsaiproject.org/wiki/Licensing:MIT#Modern_Style_with_sublicense> **[NEED TO UPDATE THIS LINK]**.
+
+    "Submit" means to use some mode of digital communication (for example, without limitation, mailing lists, bug tracking systems, and source code version control systems administered by Bonsai) to voluntarily provide a Contribution to Bonsai.
+
+    "Unlicensed" means not Licensed.
+
+    "Work" means a copyrightable work of authorship. A Work may be a portion of a larger Work, and a Work may be a modification of or addition to another Work.
+
+    "You" means the individual accepting this instance of the FPCA.
 
 
-2.  Licensed Contributions.
+    1. Copyright Permission Required for All Contributions.
 
-If Your Contribution is Licensed, Your Contribution will be governed by the terms under which it has been licensed.
+    If You are not the copyright holder of a given Contribution that You wish to Submit to Bonsai (for example, if Your employer or university holds copyright in it), it is Your responsibility to first obtain authorization from the copyright holder to Submit the Contribution under the terms of this FPCA on behalf of, or otherwise with the permission of, that copyright holder.  One form of such authorization is for the copyright holder to place, or permit You to place, an Acceptable License For Bonsai on the Contribution.
 
 
-3.  Default Licensing of Unlicensed Contributions.
+    1.  Licensed Contributions.
 
-If You Submit an Unlicensed Contribution to Bonsai, the license to the Bonsai Community for that Contribution shall be the Current Default License.
+    If Your Contribution is Licensed, Your Contribution will be governed by the terms under which it has been licensed.
 
-The **Bonsai Council** [PLACEHOLDER] may, by public announcement, subsequently designate an additional or alternative default license for a given category of Contribution (a "Later Default License"). A Later Default License shall be chosen from the appropriate categorical sublist of Acceptable Licenses For Bonsai.
 
-Once a Later Default License has been designated, Your Unlicensed Contribution shall also be licensed to the Bonsai Community under that Later Default License.  Such designation shall not affect the continuing applicability of the Current Default License to Your Contribution.
+    1.  Default Licensing of Unlicensed Contributions.
 
-You consent to having Bonsai provide reasonable notice of Your licensing of Your Contribution under the Current Default License (and, if applicable, a Later Default License) in a manner determined by Bonsai.
+    If You Submit an Unlicensed Contribution to Bonsai, the license to the Bonsai Community for that Contribution shall be the Current Default License.
 
-4.  Public Domain United States Government Works. **[NOT SURE IF WE NEED THIS SECTION; IF WE DO, DO WE NEED TO SAY SOMETHING ABOUT UK GOV?]**
+    The **Bonsai Council** [PLACEHOLDER] may, by public announcement, subsequently designate an additional or alternative default license for a given category of Contribution (a "Later Default License"). A Later Default License shall be chosen from the appropriate categorical sublist of Acceptable Licenses For Bonsai.
 
-Sections 1 through 3 of this FPCA do not apply to any Contribution to the extent that it is a work of the United States Government for which copyright is unavailable under 17 U.S.C. 105.
- 
-5.  Acceptance.
+    Once a Later Default License has been designated, Your Unlicensed Contribution shall also be licensed to the Bonsai Community under that Later Default License.  Such designation shall not affect the continuing applicability of the Current Default License to Your Contribution.
 
-You must signify Your assent to the terms of this FPCA through specific electronic means established by Bonsai (such as by click-through acceptance means).
+    You consent to having Bonsai provide reasonable notice of Your licensing of Your Contribution under the Current Default License (and, if applicable, a Later Default License) in a manner determined by Bonsai.
 
-You may also, at Your option, and without eliminating the requirement set forth in the preceding paragraph, send a copy of this FPCA, bearing Your written signature indicating Your acceptance of its terms, by email to **legal@Bonsaiproject.org [PLACEHOLDER]**, by fax to **+1 919 754 3704 [PLACEHOLDER]**, or by postal mail to:
+    1.  Public Domain United States Government Works. **[NOT SURE IF WE NEED THIS SECTION; IF WE DO, DO WE NEED TO SAY SOMETHING ABOUT UK GOV?]**
 
-  Bonsai Legal
-  c/o Red Hat, Inc.
-  100 East Davie Street
-  Raleigh, NC 27601
-  USA
-  **[PLACEHOLDER]**
+    Sections 1 through 3 of this FPCA do not apply to any Contribution to the extent that it is a work of the United States Government for which copyright is unavailable under 17 U.S.C. 105.
+    
+    1.  Acceptance.
 
+    You must signify Your assent to the terms of this FPCA through specific electronic means established by Bonsai (such as by click-through acceptance means).
+
+    You may also, at Your option, and without eliminating the requirement set forth in the preceding paragraph, send a copy of this FPCA, bearing Your written signature indicating Your acceptance of its terms, by email to **legal@Bonsaiproject.org [PLACEHOLDER]**, by fax to **+1 919 754 3704 [PLACEHOLDER]**, or by postal mail to:
+
+    Bonsai Legal  
+    c/o Red Hat, Inc.  
+    100 East Davie Street  
+    Raleigh, NC 27601  
+    USA  
+    **[PLACEHOLDER]**  
+
+``` 
 ### FAQ
 
 **Q. What is the purpose of the BPCA?**


### PR DESCRIPTION
Text of Bonsai Project Contributor Agreement was modified from the Fedora Project Contributor Agreement: https://fedoraproject.org/wiki/Legal:Fedora_Project_Contributor_Agreement

There are several "placeholders" that need to be reviewed/discussed with @glopesdev and then edited before this PR can be merged. 