### PR TITLE
Allow code blocks with empty language identifier

### DIFF
--- a/template/styles/main.js
+++ b/template/styles/main.js
@@ -43,19 +43,20 @@ $(function() {
 
     $("code.hljs").each(function() {
         var $this = $(this);
-        var language = /lang-(.+?)(\s|$)/.exec($this.attr("class"))[1].toUpperCase();
-        if (language === 'CS' || language === 'CSHARP') {
-            language = "C#";
+        var languageQuery = /lang-(.+?)(\s|$)/.exec($this.attr("class"));
+        var language = languageQuery && languageQuery.length > 1 ? languageQuery[1].toUpperCase() : null;
+        if (language && language !== 'CMD') {
+            var language = languageQuery[1].toUpperCase();
+            if (language === 'CS' || language === 'CSHARP') { language = "C#"; }
+            if (language === 'JS') { language = "JavaScript"; }
+            if (language === 'PYTHON') { language = "Python"; }
+            var $codeHeader = createCodeHeader(language);
+            var $codeElement = $this.closest("pre");
+            $codeElement.before($codeHeader);
+            $codeHeader.find("button").click(function() {
+                navigator.clipboard.writeText($codeElement.text());
+                setCopyAlert($(this));
+            });
         }
-        if (language === 'JS') {
-            language = "JavaScript";
-        }
-        var $codeHeader = createCodeHeader(language);
-        var $codeElement = $this.closest("pre");
-        $codeElement.before($codeHeader);
-        $codeHeader.find("button").click(function() {
-            navigator.clipboard.writeText($codeElement.text());
-            setCopyAlert($(this));
-        });
     });
 });


### PR DESCRIPTION
This PR handles an edge case where code blocks missing a language identifier would break the jQuery layout script inserting the DOM table header for the copy button. It also fixes casing for language identifiers commonly used in the docs.

Fixes #64 