### PR TITLE
Add extended docs for the parse operator

### DIFF
--- a/apidoc/Bonsai_Expressions_ParseBuilder.md
+++ b/apidoc/Bonsai_Expressions_ParseBuilder.md
@@ -1,0 +1,5 @@
+---
+uid: Bonsai.Expressions.ParseBuilder
+---
+
+[!include[ParseBuilder](~/articles/expressions-parse.md)]

--- a/apidoc/Bonsai_Expressions_ParseBuilder_Pattern.md
+++ b/apidoc/Bonsai_Expressions_ParseBuilder_Pattern.md
@@ -1,0 +1,28 @@
+---
+uid: Bonsai.Expressions.ParseBuilder.Pattern
+remarks: *content
+---
+
+The parse pattern may contain zero or more placeholder characters. Each placeholder is always preceded by the character `%`, and must specify one of the allowed data type format specifiers (see table below). For each placeholder in the pattern, the `Parse` method of the corresponding data type will be called to convert the matched string to an equivalent instance of that type.
+
+> [!Warning]
+> All parse conversions are done using the [invariant culture](xref:System.Globalization.CultureInfo.InvariantCulture). Specifying culture-specific conversions is not currently supported.
+
+If the parse pattern is `null` or empty, the operator will simply return the raw input value. If a non-empty parse pattern is provided, but no placeholder characters are specified, the result type will be of type <xref href="System.Reactive.Unit"/>. Otherwise, the output type will be a tuple of the types corresponding to each of the placeholder characters, in order of their appearance in the parse pattern.
+
+| Pattern | Description                                                                             |
+| ------- | --------------------------------------------------------------------------------------- |
+| `%B`    | Match an unsigned 8-bit integer ([byte](xref:System.Byte)).                             |
+| `%h`    | Match a signed 16-bit integer ([short](xref:System.Int16)).                             |
+| `%H`    | Match an unsigned 16-bit integer ([ushort](xref:System.UInt16)).                        |
+| `%i`    | Match a signed 32-bit integer ([int](xref:System.Int32)).                               |
+| `%I`    | Match an unsigned 32-bit integer ([uint](xref:System.UInt32)).                          |
+| `%l`    | Match a signed 64-bit integer ([long](xref:System.Int64)).                              |
+| `%L`    | Match an unsigned 64-bit integer ([ulong](xref:System.UInt64)).                         |
+| `%f`    | Match a single-precision floating-point number ([float](xref:System.Single)).           |
+| `%d`    | Match a double-precision floating-point number ([double](xref:System.Double)).          |
+| `%b`    | Match a Boolean (`true` or `false`) value ([bool](xref:System.Boolean)).                |
+| `%c`    | Match a single character as a UTF-16 code unit ([char](xref:System.Char)).              |
+| `%s`    | Match a text fragment using UTF-16 encoding ([string](xref:System.String)).             |
+| `%t`    | Match a timestamp measured relative to UTC time (<xref href="System.DateTimeOffset"/>). |
+| `%T`    | Match a time interval (<xref href="System.TimeSpan"/>).                                 |

--- a/apidoc/Bonsai_Expressions_ParseBuilder_Pattern.md
+++ b/apidoc/Bonsai_Expressions_ParseBuilder_Pattern.md
@@ -5,8 +5,11 @@ remarks: *content
 
 The parse pattern may contain zero or more placeholder characters. Each placeholder is always preceded by the character `%`, and must specify one of the allowed data type format specifiers (see table below). For each placeholder in the pattern, the `Parse` method of the corresponding data type will be called to convert the matched string to an equivalent instance of that type.
 
+> [!Note]
+> Some placeholder conversions will account for white space characters surrounding the input, e.g. the parse pattern `%i,%i` will work the same for `1,2` or `1, 2`.
+
 > [!Warning]
-> All parse conversions are done using the [invariant culture](xref:System.Globalization.CultureInfo.InvariantCulture). Specifying culture-specific conversions is not currently supported.
+> All parse conversions are done using the [invariant culture](xref:System.Globalization.CultureInfo.InvariantCulture). Specifying culture-specific conversions is not currently supported. There is also no support for implicit numeric conversions, e.g. attempting to parse `5.0` using `%i` will throw an error.
 
 If the parse pattern is `null` or empty, the operator will simply return the raw input value. If a non-empty parse pattern is provided, but no placeholder characters are specified, the result type will be of type <xref href="System.Reactive.Unit"/>. Otherwise, the output type will be a tuple of the types corresponding to each of the placeholder characters, in order of their appearance in the parse pattern.
 

--- a/apidoc/Bonsai_Expressions_ParseBuilder_Pattern.md
+++ b/apidoc/Bonsai_Expressions_ParseBuilder_Pattern.md
@@ -29,3 +29,6 @@ If the parse pattern is `null` or empty, the operator will simply return the raw
 | `%s`    | Match a text fragment using UTF-16 encoding ([string](xref:System.String)).             |
 | `%t`    | Match a timestamp measured relative to UTC time (<xref href="System.DateTimeOffset"/>). |
 | `%T`    | Match a time interval (<xref href="System.TimeSpan"/>).                                 |
+
+> [!Warning]
+> The parse pattern is a regular expression string and certain characters are reserved as special tokens, such as parentheses. It is possible to use these special characters by prefixing them with a backslash (e.g. `\(` for a left parentheses).

--- a/apidoc/Bonsai_Expressions_ParseBuilder_Separator.md
+++ b/apidoc/Bonsai_Expressions_ParseBuilder_Separator.md
@@ -1,0 +1,6 @@
+---
+uid: Bonsai.Expressions.ParseBuilder.Separator
+remarks: *content
+---
+
+If both <xref href="Bonsai.Expressions.ParseBuilder.Separator"/> and <xref href="Bonsai.Expressions.ParseBuilder.Pattern"/> are specified, the separator will be used first to split the input strings. Each delimited substring will then be matched against the regular expression specified in the parse pattern. The result will be an array of the output type inferred from the structure of the parse pattern.

--- a/articles/expressions-parse.md
+++ b/articles/expressions-parse.md
@@ -1,0 +1,19 @@
+---
+uid: expressions-parse
+title: "Parse"
+---
+
+The `Parse` operator is a [Transform](xref:operators#transform) on sequences of <xref href="System.String"/> values. Each of the strings in the sequence will be matched against the specified <xref href="Bonsai.Expressions.ParseBuilder.Pattern"/> using the .NET regular expression engine (<xref href="System.Text.RegularExpressions.Regex"/>). If a <xref href="Bonsai.Expressions.ParseBuilder.Separator"/> is specified, every input string will first be split into substrings using the specified delimiter before passing them into the regular expression.
+
+The output type is automatically inferred from the structure of the parse pattern. If a separator is used, the output will be an array storing the results of matching each delimited substring against the parse pattern. If any of the values in the input sequence fails to match against the specified pattern, an error will be raised and the sequence will be terminated. For more flexible parsing, it is possible to chain multiple `Parse` operators in a sequence by parsing only specific sub-strings of the input, and passing the remainder of the string downstream for further processing.
+
+## Examples
+
+The following examples illustrate using different combinations of the <xref href="Bonsai.Expressions.ParseBuilder.Pattern"/> and <xref href="Bonsai.Expressions.ParseBuilder.Separator"/> properties to match different kinds of formatted text data.
+
+| Pattern    | Separator | Type                          | Description |
+| ---------- | --------- | ----------------------------- | ----------- |
+| `%f`       |           | [float](xref:System.Single)   | Match a floating-point number. |
+| `%f;%i`    |           | [Tuple](xref:System.Tuple`2)<[float](xref:System.Single), [int](xref:System.Int32)>  | Match a floating-point number and an integer separated by a semi-colon. |
+| `%f`       | `,`       | [float](xref:System.Single)[] | Match each comma-delimited substring with a floating-point number. |
+| `%s,%b`    | `\t`      | [Tuple](xref:System.Tuple`2)<[string](xref:System.String), [bool](xref:System.Boolean)>[] | Match each tab-delimited substring with a pair of string and boolean, separated by a comma. |

--- a/articles/expressions-parse.md
+++ b/articles/expressions-parse.md
@@ -3,17 +3,24 @@ uid: expressions-parse
 title: "Parse"
 ---
 
-The `Parse` operator is a [Transform](xref:operators#transform) on sequences of <xref href="System.String"/> values. Each of the strings in the sequence will be matched against the specified <xref href="Bonsai.Expressions.ParseBuilder.Pattern"/> using the .NET regular expression engine (<xref href="System.Text.RegularExpressions.Regex"/>). If a <xref href="Bonsai.Expressions.ParseBuilder.Separator"/> is specified, every input string will first be split into substrings using the specified delimiter before passing them into the regular expression.
+The `Parse` operator is a [Transform](xref:operators#transform) on sequences of <xref href="System.String"/> values. Each of the strings in the sequence will be matched against the specified <xref href="Bonsai.Expressions.ParseBuilder.Pattern"/> using the .NET regular expression engine (<xref href="System.Text.RegularExpressions.Regex"/>). If a <xref href="Bonsai.Expressions.ParseBuilder.Separator"/> is specified, every input string will first be split using the delimiter, and each substring will then be matched against the regular expression.
 
-The output type is automatically inferred from the structure of the parse pattern. If a separator is used, the output will be an array storing the results of matching each delimited substring against the parse pattern. If any of the values in the input sequence fails to match against the specified pattern, an error will be raised and the sequence will be terminated. For more flexible parsing, it is possible to chain multiple `Parse` operators in a sequence by parsing only specific sub-strings of the input, and passing the remainder of the string downstream for further processing.
+The output type is automatically inferred from the structure of the parse pattern. If a separator is used, the output will be an array containing the results of matching each delimited substring against the parse pattern. If any of the values in the input sequence fails to match, an error will be raised and the sequence will be terminated.
+
+> [!Note]
+> Multi-character strings can be used to specify both the pattern and the separator. This can sometimes help to parse text formats with more complex tokens. For more flexible or conditional parsing, it is also possible to chain multiple `Parse` operators in a sequence, by matching against the placeholder `%s` at the end of the sequence. This will match and capture any remaining text for downstream processing.
+
+> [!Warning]
+> For convenience, both <xref href="Bonsai.Expressions.ParseBuilder.Pattern"/> and <xref href="Bonsai.Expressions.ParseBuilder.Separator"/> properties will accept the use of character escapes to represent specific white space or unicode characters. See the [list of supported character escapes in .NET](https://learn.microsoft.com/en-us/dotnet/standard/base-types/character-escapes-in-regular-expressions#character-escapes-in-net) for more information.
 
 ## Examples
 
 The following examples illustrate using different combinations of the <xref href="Bonsai.Expressions.ParseBuilder.Pattern"/> and <xref href="Bonsai.Expressions.ParseBuilder.Separator"/> properties to match different kinds of formatted text data.
 
-| Pattern    | Separator | Type                          | Description |
-| ---------- | --------- | ----------------------------- | ----------- |
-| `%f`       |           | [float](xref:System.Single)   | Match a floating-point number. |
-| `%f;%i`    |           | [Tuple](xref:System.Tuple`2)<[float](xref:System.Single), [int](xref:System.Int32)>  | Match a floating-point number and an integer separated by a semi-colon. |
-| `%f`       | `,`       | [float](xref:System.Single)[] | Match each comma-delimited substring with a floating-point number. |
-| `%s,%b`    | `\t`      | [Tuple](xref:System.Tuple`2)<[string](xref:System.String), [bool](xref:System.Boolean)>[] | Match each tab-delimited substring with a pair of string and boolean, separated by a comma. |
+| Pattern     | Separator | Type                          | Description | Example |
+| ----------- | --------- | ----------------------------- | ----------- | ------- |
+| `%f`        |           | [float](xref:System.Single)   | Match a floating-point number. | `5.0` |
+| `%f;%i`     |           | [Tuple](xref:System.Tuple`2)<[float](xref:System.Single), [int](xref:System.Int32)>  | Match a floating-point number and an integer separated by a semicolon. | `5.1;5`
+| `%f`        | `,`       | [float](xref:System.Single)[] | Match each comma-delimited substring with a floating-point number. | `3.2, 5.6, 8.9` |
+| `\(%f,%f\)` | `;`       | [Tuple](xref:System.Tuple`2)<[float](xref:System.Single), [float](xref:System.Single)>[] | Match each semicolon-delimited substring with a pair of floating-point numbers surrounded by parentheses. | `(1, 2); (3.14, 4.5)` |
+| `%s,msg:%b` | `\t`      | [Tuple](xref:System.Tuple`2)<[string](xref:System.String), [bool](xref:System.Boolean)>[] | Match each tab-delimited substring with a pattern containing a string and boolean. | `tag1,msg:true tag2,msg:false` |


### PR DESCRIPTION
This PR adds extended documentation for the `Parse` operator. It describes in detail the workings of the `Pattern` and `Separator` properties and how they can be used by themselves, or in combination. It also describes each of the placeholder strings, and includes a small table with examples for matching different types of formatted strings.