### PR TITLE
Add extended documentation for property sources

### DIFF
--- a/apidoc/Bonsai_Expressions_BooleanProperty.md
+++ b/apidoc/Bonsai_Expressions_BooleanProperty.md
@@ -1,0 +1,5 @@
+---
+uid: Bonsai.Expressions.BooleanProperty
+---
+
+[!include[PropertySource](~/articles/expressions-propertysource.md)]

--- a/apidoc/Bonsai_Expressions_ByteProperty.md
+++ b/apidoc/Bonsai_Expressions_ByteProperty.md
@@ -1,0 +1,5 @@
+---
+uid: Bonsai.Expressions.ByteProperty
+---
+
+[!include[PropertySource](~/articles/expressions-propertysource.md)]

--- a/apidoc/Bonsai_Expressions_DateTimeOffsetProperty.md
+++ b/apidoc/Bonsai_Expressions_DateTimeOffsetProperty.md
@@ -1,0 +1,5 @@
+---
+uid: Bonsai.Expressions.DateTimeOffsetProperty
+---
+
+[!include[PropertySource](~/articles/expressions-propertysource.md)]

--- a/apidoc/Bonsai_Expressions_DateTimeProperty.md
+++ b/apidoc/Bonsai_Expressions_DateTimeProperty.md
@@ -1,0 +1,5 @@
+---
+uid: Bonsai.Expressions.DateTimeProperty
+---
+
+[!include[PropertySource](~/articles/expressions-propertysource.md)]

--- a/apidoc/Bonsai_Expressions_DoubleProperty.md
+++ b/apidoc/Bonsai_Expressions_DoubleProperty.md
@@ -1,0 +1,5 @@
+---
+uid: Bonsai.Expressions.DoubleProperty
+---
+
+[!include[PropertySource](~/articles/expressions-propertysource.md)]

--- a/apidoc/Bonsai_Expressions_FloatProperty.md
+++ b/apidoc/Bonsai_Expressions_FloatProperty.md
@@ -1,0 +1,5 @@
+---
+uid: Bonsai.Expressions.FloatProperty
+---
+
+[!include[PropertySource](~/articles/expressions-propertysource.md)]

--- a/apidoc/Bonsai_Expressions_Int64Property.md
+++ b/apidoc/Bonsai_Expressions_Int64Property.md
@@ -1,0 +1,5 @@
+---
+uid: Bonsai.Expressions.Int64Property
+---
+
+[!include[PropertySource](~/articles/expressions-propertysource.md)]

--- a/apidoc/Bonsai_Expressions_IntProperty.md
+++ b/apidoc/Bonsai_Expressions_IntProperty.md
@@ -1,0 +1,5 @@
+---
+uid: Bonsai.Expressions.IntProperty
+---
+
+[!include[PropertySource](~/articles/expressions-propertysource.md)]

--- a/apidoc/Bonsai_Expressions_PropertySource.md
+++ b/apidoc/Bonsai_Expressions_PropertySource.md
@@ -1,0 +1,5 @@
+---
+uid: Bonsai.Expressions.PropertySource
+---
+
+[!include[PropertySource](~/articles/expressions-propertysource.md)]

--- a/apidoc/Bonsai_Expressions_PropertySource_2.md
+++ b/apidoc/Bonsai_Expressions_PropertySource_2.md
@@ -1,0 +1,5 @@
+---
+uid: Bonsai.Expressions.PropertySource`2
+---
+
+[!include[PropertySource](~/articles/expressions-propertysource.md)]

--- a/apidoc/Bonsai_Expressions_StringProperty.md
+++ b/apidoc/Bonsai_Expressions_StringProperty.md
@@ -1,0 +1,5 @@
+---
+uid: Bonsai.Expressions.StringProperty
+---
+
+[!include[PropertySource](~/articles/expressions-propertysource.md)]

--- a/apidoc/Bonsai_Expressions_TimeSpanProperty.md
+++ b/apidoc/Bonsai_Expressions_TimeSpanProperty.md
@@ -1,0 +1,5 @@
+---
+uid: Bonsai.Expressions.TimeSpanProperty
+---
+
+[!include[PropertySource](~/articles/expressions-propertysource.md)]

--- a/apidoc/Bonsai_Expressions_WorkflowProperty.md
+++ b/apidoc/Bonsai_Expressions_WorkflowProperty.md
@@ -1,0 +1,5 @@
+---
+uid: Bonsai.Expressions.WorkflowProperty
+---
+
+[!include[PropertySource](~/articles/expressions-propertysource.md)]

--- a/apidoc/Bonsai_Expressions_WorkflowProperty_1.md
+++ b/apidoc/Bonsai_Expressions_WorkflowProperty_1.md
@@ -1,0 +1,5 @@
+---
+uid: Bonsai.Expressions.WorkflowProperty`1
+---
+
+[!include[PropertySource](~/articles/expressions-propertysource.md)]

--- a/articles/expressions-propertysource.md
+++ b/articles/expressions-propertysource.md
@@ -1,0 +1,4 @@
+Property sources expose a value which can be set from the property grid and also generate an observable sequence that emits a notification whenever the property value changes, starting with the initial property value.
+
+> [!Tip]
+> Property sources are commonly used to create new configuration parameters with custom names for nested workflows. To expose and rename a property source, use [**Property Mapping**](xref:property-mapping#externalized-properties) to externalize the property value and set its [`DisplayName`](xref:Bonsai.Expressions.ExternalizedMapping.DisplayName).


### PR DESCRIPTION
This PR adds extended documentation for property sources. Both built-in workflow properties (e.g. `BooleanProperty`, `ByteProperty`, etc.) and editor-created property sources share the same basic logic.