### PR TITLE
Add extended documentation for binary operators

### DIFF
--- a/apidoc/Bonsai_Expressions_AddBuilder.md
+++ b/apidoc/Bonsai_Expressions_AddBuilder.md
@@ -1,0 +1,5 @@
+---
+uid: Bonsai.Expressions.AddBuilder
+---
+
+[!include[BinaryOperator](~/articles/expressions-binaryoperator.md)]

--- a/apidoc/Bonsai_Expressions_BitwiseAndBuilder.md
+++ b/apidoc/Bonsai_Expressions_BitwiseAndBuilder.md
@@ -1,0 +1,5 @@
+---
+uid: Bonsai.Expressions.BitwiseAndBuilder
+---
+
+[!include[BinaryOperator](~/articles/expressions-binaryoperator.md)]

--- a/apidoc/Bonsai_Expressions_BitwiseOrBuilder.md
+++ b/apidoc/Bonsai_Expressions_BitwiseOrBuilder.md
@@ -1,0 +1,5 @@
+---
+uid: Bonsai.Expressions.BitwiseOrBuilder
+---
+
+[!include[BinaryOperator](~/articles/expressions-binaryoperator.md)]

--- a/apidoc/Bonsai_Expressions_DivideBuilder.md
+++ b/apidoc/Bonsai_Expressions_DivideBuilder.md
@@ -1,0 +1,5 @@
+---
+uid: Bonsai.Expressions.DivideBuilder
+---
+
+[!include[BinaryOperator](~/articles/expressions-binaryoperator.md)]

--- a/apidoc/Bonsai_Expressions_EqualBuilder.md
+++ b/apidoc/Bonsai_Expressions_EqualBuilder.md
@@ -1,0 +1,5 @@
+---
+uid: Bonsai.Expressions.EqualBuilder
+---
+
+[!include[BinaryOperator](~/articles/expressions-binaryoperator.md)]

--- a/apidoc/Bonsai_Expressions_GetValueOrDefaultBuilder.md
+++ b/apidoc/Bonsai_Expressions_GetValueOrDefaultBuilder.md
@@ -1,0 +1,5 @@
+---
+uid: Bonsai.Expressions.GetValueOrDefaultBuilder
+---
+
+[!include[BinaryOperatorArgument](~/articles/expressions-binaryoperator-argument.md)]

--- a/apidoc/Bonsai_Expressions_GreaterThanBuilder.md
+++ b/apidoc/Bonsai_Expressions_GreaterThanBuilder.md
@@ -1,0 +1,5 @@
+---
+uid: Bonsai.Expressions.GreaterThanBuilder
+---
+
+[!include[BinaryOperator](~/articles/expressions-binaryoperator.md)]

--- a/apidoc/Bonsai_Expressions_GreaterThanOrEqualBuilder.md
+++ b/apidoc/Bonsai_Expressions_GreaterThanOrEqualBuilder.md
@@ -1,0 +1,5 @@
+---
+uid: Bonsai.Expressions.GreaterThanOrEqualBuilder
+---
+
+[!include[BinaryOperator](~/articles/expressions-binaryoperator.md)]

--- a/apidoc/Bonsai_Expressions_IndexBuilder.md
+++ b/apidoc/Bonsai_Expressions_IndexBuilder.md
@@ -1,0 +1,5 @@
+---
+uid: Bonsai.Expressions.IndexBuilder
+---
+
+[!include[BinaryOperatorArgument](~/articles/expressions-binaryoperator-argument.md)]

--- a/apidoc/Bonsai_Expressions_LeftShiftBuilder.md
+++ b/apidoc/Bonsai_Expressions_LeftShiftBuilder.md
@@ -1,0 +1,5 @@
+---
+uid: Bonsai.Expressions.LeftShiftBuilder
+---
+
+[!include[BinaryOperatorArgument](~/articles/expressions-binaryoperator-argument.md)]

--- a/apidoc/Bonsai_Expressions_LessThanBuilder.md
+++ b/apidoc/Bonsai_Expressions_LessThanBuilder.md
@@ -1,0 +1,5 @@
+---
+uid: Bonsai.Expressions.LessThanBuilder
+---
+
+[!include[BinaryOperator](~/articles/expressions-binaryoperator.md)]

--- a/apidoc/Bonsai_Expressions_LessThanOrEqualBuilder.md
+++ b/apidoc/Bonsai_Expressions_LessThanOrEqualBuilder.md
@@ -1,0 +1,5 @@
+---
+uid: Bonsai.Expressions.LessThanOrEqualBuilder
+---
+
+[!include[BinaryOperator](~/articles/expressions-binaryoperator.md)]

--- a/apidoc/Bonsai_Expressions_LogicalAndBuilder.md
+++ b/apidoc/Bonsai_Expressions_LogicalAndBuilder.md
@@ -1,0 +1,5 @@
+---
+uid: Bonsai.Expressions.LogicalAndBuilder
+---
+
+[!include[BinaryOperator](~/articles/expressions-binaryoperator.md)]

--- a/apidoc/Bonsai_Expressions_LogicalOrBuilder.md
+++ b/apidoc/Bonsai_Expressions_LogicalOrBuilder.md
@@ -1,0 +1,5 @@
+---
+uid: Bonsai.Expressions.LogicalOrBuilder
+---
+
+[!include[BinaryOperator](~/articles/expressions-binaryoperator.md)]

--- a/apidoc/Bonsai_Expressions_ModBuilder.md
+++ b/apidoc/Bonsai_Expressions_ModBuilder.md
@@ -1,0 +1,5 @@
+---
+uid: Bonsai.Expressions.ModBuilder
+---
+
+[!include[BinaryOperator](~/articles/expressions-binaryoperator.md)]

--- a/apidoc/Bonsai_Expressions_MultiplyBuilder.md
+++ b/apidoc/Bonsai_Expressions_MultiplyBuilder.md
@@ -1,0 +1,5 @@
+---
+uid: Bonsai.Expressions.MultiplyBuilder
+---
+
+[!include[BinaryOperator](~/articles/expressions-binaryoperator.md)]

--- a/apidoc/Bonsai_Expressions_NotEqualBuilder.md
+++ b/apidoc/Bonsai_Expressions_NotEqualBuilder.md
@@ -1,0 +1,5 @@
+---
+uid: Bonsai.Expressions.NotEqualBuilder
+---
+
+[!include[BinaryOperator](~/articles/expressions-binaryoperator.md)]

--- a/apidoc/Bonsai_Expressions_RightShiftBuilder.md
+++ b/apidoc/Bonsai_Expressions_RightShiftBuilder.md
@@ -1,0 +1,5 @@
+---
+uid: Bonsai.Expressions.RightShiftBuilder
+---
+
+[!include[BinaryOperatorArgument](~/articles/expressions-binaryoperator-argument.md)]

--- a/apidoc/Bonsai_Expressions_SubtractBuilder.md
+++ b/apidoc/Bonsai_Expressions_SubtractBuilder.md
@@ -1,0 +1,5 @@
+---
+uid: Bonsai.Expressions.SubtractBuilder
+---
+
+[!include[BinaryOperator](~/articles/expressions-binaryoperator.md)]

--- a/apidoc/Bonsai_Expressions_XorBuilder.md
+++ b/apidoc/Bonsai_Expressions_XorBuilder.md
@@ -1,0 +1,5 @@
+---
+uid: Bonsai.Expressions.XorBuilder
+---
+
+[!include[BinaryOperator](~/articles/expressions-binaryoperator.md)]

--- a/articles/expressions-binaryoperator-argument.md
+++ b/articles/expressions-binaryoperator-argument.md
@@ -1,0 +1,4 @@
+> [!Note]
+> If the operator is applied to a sequence of single values, a workflow property will be inferred based on compatible operator overloads and exposed in the property grid. The value of this property will be used as the argument when applying the operator to the elements in the source sequence.
+
+If the operator is applied to a sequence of pairs of values, the second element in the pair is considered to be the argument to the operator.

--- a/articles/expressions-binaryoperator.md
+++ b/articles/expressions-binaryoperator.md
@@ -1,0 +1,4 @@
+Binary operators are applied over sequences of pairs of values, as long as the corresponding arithmetic and logic operator exists for the specific combination of input types.
+
+> [!Note]
+> Binary arithmetic and logic operators can also be applied to sequences of single values. In this case, a workflow property will be inferred based on the type of the elements in the source sequence and exposed in the property grid. The value of this property will be used as the right-hand side when applying the binary operator to the elements in the source sequence.


### PR DESCRIPTION
This PR adds documentation on some of the nuances of using the built-in binary operators, including rules for operating on sequences of pairs, or sequences of single values with automatically inferred properties.