### PR TITLE
Add extended documentation for nesting group nodes

### DIFF
--- a/apidoc/Bonsai_Expressions_GroupWorkflowBuilder.md
+++ b/apidoc/Bonsai_Expressions_GroupWorkflowBuilder.md
@@ -1,0 +1,5 @@
+---
+uid: Bonsai.Expressions.GroupWorkflowBuilder
+---
+
+[!include[GroupWorkflow](~/articles/expressions-groupworkflow.md)]

--- a/apidoc/Bonsai_Expressions_IncludeWorkflowBuilder.md
+++ b/apidoc/Bonsai_Expressions_IncludeWorkflowBuilder.md
@@ -1,0 +1,5 @@
+---
+uid: Bonsai.Expressions.IncludeWorkflowBuilder
+---
+
+[!include[IncludeWorkflow](~/articles/expressions-includeworkflow.md)]

--- a/apidoc/Bonsai_Expressions_WorkflowInputBuilder.md
+++ b/apidoc/Bonsai_Expressions_WorkflowInputBuilder.md
@@ -1,0 +1,5 @@
+---
+uid: Bonsai.Expressions.WorkflowInputBuilder
+---
+
+[!include[WorkflowInput](~/articles/expressions-workflowinput.md)]

--- a/apidoc/Bonsai_Expressions_WorkflowInputBuilder_1.md
+++ b/apidoc/Bonsai_Expressions_WorkflowInputBuilder_1.md
@@ -1,0 +1,5 @@
+---
+uid: Bonsai.Expressions.WorkflowInputBuilder`1
+---
+
+[!include[WorkflowInput](~/articles/expressions-workflowinput.md)]

--- a/apidoc/Bonsai_Expressions_WorkflowOutputBuilder.md
+++ b/apidoc/Bonsai_Expressions_WorkflowOutputBuilder.md
@@ -1,0 +1,5 @@
+---
+uid: Bonsai.Expressions.WorkflowOutputBuilder
+---
+
+[!include[WorkflowOutput](~/articles/expressions-workflowoutput.md)]

--- a/articles/expressions-groupworkflow.md
+++ b/articles/expressions-groupworkflow.md
@@ -1,0 +1,13 @@
+---
+uid: expressions-groupworkflow
+title: "GroupWorkflow"
+---
+
+The workflow nested inside `GroupWorkflow` specifies the entire behavior of this operator. Group nodes are used to organize larger workflows into modular building blocks. For most purposes, moving operations into a group workflow will not have any effects on the performance or function of the program.
+
+All observable sequences passed as arguments to the outer `GroupWorkflow` will be routed to the inner [WorkflowInput](xref:Bonsai.Expressions.WorkflowInputBuilder) nodes. Conversely, all notifications emitted by the sequence connected to the single [WorkflowOutput](xref:Bonsai.Expressions.WorkflowOutputBuilder) node will be passed to any observers of the group node. It is possible to subscribe multiple times to the same group, in which case the nested workflow will run potentially in parallel and is considered to be reentrant.
+
+> [!Tip]
+> Use [**ExternalizedMapping**](xref:Bonsai.Expressions.ExternalizedMappingBuilder) operators to expose configurable properties when selecting the nested workflow node. Externalized properties in a nested workflow work the same way as regular properties in other operators. They can be further externalized as part of other nested operators or dynamically assigned using [**PropertyMapping**](xref:Bonsai.Expressions.PropertyMappingBuilder) or [**InputMapping**](xref:Bonsai.Expressions.InputMappingBuilder) operators.
+
+[!include[SharedState](~/articles/expressions-sharedstate.md)]

--- a/articles/expressions-includeworkflow.md
+++ b/articles/expressions-includeworkflow.md
@@ -1,0 +1,13 @@
+---
+uid: expressions-includeworkflow
+title: "IncludeWorkflow"
+---
+
+The `IncludeWorkflow` operator works in exactly the same way as [GroupWorkflow](xref:Bonsai.Expressions.GroupWorkflowBuilder), with the difference that the nested workflow definition is stored externally in a file, rather than locally in the node itself. Include nodes are used to organize larger workflows into modular building blocks. They allow reusing functionality across different parts of a workflow, or even across different projects. Changing the definition of an included workflow will be automatically reflected in all places where that workflow is reused.
+
+All observable sequences passed as arguments to the outer `IncludeWorkflow` will be routed to the inner [WorkflowInput](xref:Bonsai.Expressions.WorkflowInputBuilder) nodes. Conversely, all notifications emitted by the sequence connected to the single [WorkflowOutput](xref:Bonsai.Expressions.WorkflowOutputBuilder) node will be passed to any observers of the include workflow node. It is possible to subscribe multiple times to the same include workflow, in which case the nested workflow will run potentially in parallel and is considered to be reentrant.
+
+> [!Note]
+> Externalized properties contained inside the included workflow will be exposed when selecting the `IncludeWorkflow` node. Any changes to the values of these properties can be recovered, even if the included workflow is reused multiple times in different parts of the program. They can also be further externalized as part of other nested operators or dynamically assigned using [**PropertyMapping**](xref:Bonsai.Expressions.PropertyMappingBuilder) or [**InputMapping**](xref:Bonsai.Expressions.InputMappingBuilder) operators.
+
+[!include[SharedState](~/articles/expressions-sharedstate.md)]

--- a/articles/expressions-sharedstate.md
+++ b/articles/expressions-sharedstate.md
@@ -1,0 +1,2 @@
+> [!Warning]
+> If the nested workflow is reentrant, properties of inner nodes are shared by all asynchronous operations which are running simultaneously. If the shared state never changes across reentrant operations (i.e. the state is immutable), this is not a problem. If shared state is changing dynamically, you should consider using synchronization primitives to make sure that state updates are coordinated across the different asynchronous operations.

--- a/articles/expressions-workflowinput.md
+++ b/articles/expressions-workflowinput.md
@@ -1,0 +1,9 @@
+---
+uid: expressions-workflowinput
+title: "WorkflowInput"
+---
+
+The `WorkflowInput` operator is used inside nested workflows to route input arguments from the outside. The type of the input sequence and its behavior is dependent on the exact operator in which they are nested. Each `WorkflowInput` is uniquely numbered starting from `Source1`.
+
+> [!Warning]
+> The numbering of the `WorkfklowInput` nodes usually reflects the order of arguments in the outer operator, but this is not always required. In fact, how many input arguments are available in the nested workflow is entirely dependent on the nesting operator.

--- a/articles/expressions-workflowoutput.md
+++ b/articles/expressions-workflowoutput.md
@@ -1,0 +1,11 @@
+---
+uid: expressions-workflowoutput
+title: "WorkflowOutput"
+---
+
+The `WorkflowOutput` operator is used inside nested workflows to specify the sequence of notifications providing the result of the nested function. In each workflow there can only be at most one `WorkflowOutput` node. How this result sequence is converted into the sequence of notifications of the outer nesting node is dependent on the exact operator in which the output is nested.
+
+If no `WorkflowOutput` is specified, the result sequence of any nested workflow (including the top-level workflow) will be of type [Unit](xref:System.Reactive.Unit) and will not emit any notifications except for successful termination if all inner sequences terminate successfully, or exceptional termination if any of the inner sequences raises an error.
+
+> [!Note]
+> If the sequence connected to `WorkflowOutput` terminates successfully, all other nested operators will be immediately cancelled. This is also true for the top-level workflow, in which case the entire program execution is terminated.


### PR DESCRIPTION
This PR adds extended documentation covering details of the core nesting group nodes: `GroupWorkflow` and `IncludeWorkflow`. It also discusses the details of routing inputs and outputs to the nested workflow using the `WorkflowInput` and `WorkflowOutput` operators.