### PR TITLE
Add extended documentation for missing core operators

### DIFF
--- a/apidoc/Bonsai_Expressions_DisableBuilder.md
+++ b/apidoc/Bonsai_Expressions_DisableBuilder.md
@@ -1,0 +1,5 @@
+---
+uid: Bonsai.Expressions.DisableBuilder
+---
+
+[!include[Disable](~/articles/expressions-disable.md)]

--- a/apidoc/Bonsai_Expressions_MemberSelectorBuilder.md
+++ b/apidoc/Bonsai_Expressions_MemberSelectorBuilder.md
@@ -1,0 +1,5 @@
+---
+uid: Bonsai.Expressions.MemberSelectorBuilder
+---
+
+[!include[MemberSelector](~/articles/expressions-memberselector.md)]

--- a/apidoc/Bonsai_Expressions_UnitBuilder.md
+++ b/apidoc/Bonsai_Expressions_UnitBuilder.md
@@ -1,0 +1,5 @@
+---
+uid: Bonsai.Expressions.UnitBuilder
+---
+
+[!include[Unit](~/articles/expressions-unit.md)]

--- a/apidoc/Bonsai_Expressions_UnknownTypeBuilder.md
+++ b/apidoc/Bonsai_Expressions_UnknownTypeBuilder.md
@@ -1,0 +1,5 @@
+---
+uid: Bonsai.Expressions.UnknownTypeBuilder
+---
+
+[!include[UnknownType](~/articles/expressions-unknowntype.md)]

--- a/articles/expressions-disable.md
+++ b/articles/expressions-disable.md
@@ -1,0 +1,6 @@
+---
+uid: expressions-disable
+title: "Disable"
+---
+
+The `Disable` decorator is used to remove expressions from the workflow build process without actually removing the expressions themselves from the workflow. It is most frequently used for rapid-prototyping of alternative solutions, or during debugging to quickly activate or deactivate branches for testing.

--- a/articles/expressions-memberselector.md
+++ b/articles/expressions-memberselector.md
@@ -1,0 +1,8 @@
+---
+uid: expressions-memberselector
+title: "MemberSelector"
+---
+
+The `MemberSelector` operator is used to quickly extract member fields and properties out of the elements of the source sequence. Multiple members can be specified using a comma-separated list in the <xref href="Bonsai.Expressions.MemberSelectorBuilder.Selector"/> property, in which case the output type will be a tuple of all selected member types.
+
+The <xref href="Bonsai.Expressions.MemberSelectorBuilder.TypeMapping"/> property can be used to specify which type conversion to use when chaining the selected members into downstream operators.

--- a/articles/expressions-unit.md
+++ b/articles/expressions-unit.md
@@ -1,0 +1,9 @@
+---
+uid: expressions-unit
+title: "Unit"
+---
+
+The `Unit` operator generates a sequence returning the singleton unit object, if no input sequence is provided. Otherwise, it will convert all elements in the source sequence to the <xref href="System.Reactive.Unit"/> type.
+
+> [!Tip]
+> `Unit` is most commonly used for converting separate branches with different types into a common type signature, so they can be combined using control flow operators such as [**Merge**](xref:Bonsai.Reactive.Merge) or [**Concat**](xref:Bonsai.Reactive.Concat).

--- a/articles/expressions-unknowntype.md
+++ b/articles/expressions-unknowntype.md
@@ -3,5 +3,5 @@ uid: expressions-unknowntype
 title: "UnknownType"
 ---
 
-> [!Note]
+> [!Important]
 > Unknown types are created when the compiler is unable to resolve a type reference specified in the workflow. This is usually caused by a missing package that needs to be installed, but sometimes it might also indicate missing native dependencies required by the package. Please refer to the specific package documentation for guidance when debugging unknown types.

--- a/articles/expressions-unknowntype.md
+++ b/articles/expressions-unknowntype.md
@@ -1,0 +1,7 @@
+---
+uid: expressions-unknowntype
+title: "UnknownType"
+---
+
+> [!Note]
+> Unknown types are created when the compiler is unable to resolve a type reference specified in the workflow. This is usually caused by a missing package that needs to be installed, but sometimes it might also indicate missing native dependencies required by the package. Please refer to the specific package documentation for guidance when debugging unknown types.


### PR DESCRIPTION
This PR adds missing extended documentation for the `Unit`, `MemberSelector`, `UnknownTypeBuilder` and `DisableBuilder` operators. These operators round up the main core functionality of the expressions namespace.