### PR TITLE
Make GitHub Pages deployment optional on non-canonical forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,4 +38,5 @@ jobs:
         uses: actions/upload-pages-artifact@v3
 
       - name: Deploy to GitHub Pages
+        continue-on-error: ${{vars.IS_CANONICAL_DOCS_REPO != 'true'}}
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
With this approach the error still appears in the workflow run overview letting the user know what they need to change.

This approach also avoids requiring forks to add an Actions variable *and* changing the GitHub Pages deployment setting. (They'll only need to do the latter.)

Fixes https://github.com/bonsai-rx/docs/issues/88