### PR TITLE
Update docfx version and export sitemap

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,10 +3,11 @@
   "isRoot": true,
   "tools": {
     "docfx": {
-      "version": "2.75.3",
+      "version": "2.77.0",
       "commands": [
         "docfx"
-      ]
+      ],
+      "rollForward": false
     }
   }
 }

--- a/docfx.json
+++ b/docfx.json
@@ -75,6 +75,11 @@
         "apiSpecFolder": "apidoc"
       }
     },
+    "sitemap": {
+      "baseUrl": "https://bonsai-rx.org/docs",
+      "priority": 0.5,
+      "changefreq": "monthly"
+    },
     "dest": "_site",
     "globalMetadataFiles": [],
     "fileMetadataFiles": [],


### PR DESCRIPTION
The new DocFX release resolves the regression with external `xrefmap.yml` files so we are again safe to upgrade. Following the recommendation in #90 we have also turned on exporting of the `sitemap.xml` file for more efficient crawling.