### PR TITLE
Use deployment key in CI for manipulating Git repository

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -32,6 +32,8 @@ jobs:
       # ----------------------------------------------------------------------- Checkout
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ssh-key: ${{secrets.CI_DEPLOYMENT_KEY}}
 
       # ----------------------------------------------------------------------- Override the submodule URL
       # This is to support testing release automation in forks, it is disabled for the canonical docs repo
@@ -84,10 +86,3 @@ jobs:
       - name: Push changes
         if: steps.pre-commit-check.outputs.continue == 'true'
         run: git push
-      # The above push will not actually trigger a deployment as actions performed using temporary GitHub Actions tokens
-      # do not trigger events in order to avoid unintentional recursion. As such we manually trigger deployment.
-      - name: Trigger GitHub Pages deployment
-        if: steps.pre-commit-check.outputs.continue == 'true'
-        run: gh workflow run build.yml
-        env:
-          GH_TOKEN: ${{github.token}}


### PR DESCRIPTION
This allows CI to bypass the pull request requirement for pushing to `main`

As an unintended consequence of this change, the manual GitHub Pages deployment is no longer necessary as GitHub's recursion protection doesn't block pushes from deployment keys.

A nice side-effect of this is that the build of the docs repo upon release is now attributed to a human rather than the GitHub Actions bot, which means that build failure notifications actually go to someone now 😁