### PR TITLE
Remove bootstrapper projects from docfx metadata

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -10,7 +10,10 @@
             "**/bin/**",
             "**/obj/**",
             "**/**.Tests/**",
+            "**/Bonsai.csproj",
+            "**/Bonsai32.csproj",
             "**/Bonsai.NuGet**/**",
+            "**/Bonsai.Player**/**",
             "**/Bonsai.Configuration/**",
             "**/Bonsai.StarterPack**/**",
             "**/Bonsai.Templates/**"


### PR DESCRIPTION
Recent CI builds started failing due to issues resolving project reference dependencies internal to the bootstrapper projects. The reason is unknown although the logs reveal several issues relating to NuGet audit failures.

Further investigation might reveal a reason, however, bootstrapper projects do not currently contain any public APIs and so do not contain XML documentation comments. Their CLI interface is currently documented manually and therefore they do not need to be included in docfx metadata.

This PR fixes the CI build issue and improves docs build times by simply removing all bootstrapper projects and their indirect dependencies from the docfx metadata.