### PR TITLE
Flatten table of contents for conceptual documentation

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "docfx": {
-      "version": "2.77.0",
+      "version": "2.78.2",
       "commands": [
         "docfx"
       ],

--- a/articles/cli.md
+++ b/articles/cli.md
@@ -1,11 +1,10 @@
 ---
 uid: cli
-title: "Command Line Interface"
 ---
 
-# Command Line Interface (CLI)
+# Command Line Interface
 
-The Bonsai command-line interface makes it possible to interface with Bonsai directly from the operating system terminal. Using the CLI you can open files, set workflow properties, change the editor scale, run a workflow in application mode, or even export a workflow as a bitmap or vector graphics file.
+The Bonsai command line interface (CLI) makes it possible to interface with Bonsai directly from the operating system terminal. Using the CLI you can open files, set workflow properties, change the editor scale, run a workflow in application mode, or even export a workflow as a bitmap or vector graphics file.
 
 ## Quick Start
 

--- a/articles/create-package.md
+++ b/articles/create-package.md
@@ -1,9 +1,8 @@
 ---
 uid: create-package
-title: "Creating a Package"
 ---
 
-# Creating a Package
+# Create a Package
 
 The Bonsai language can be extended with custom packages, which are installed and shared using [NuGet](https://learn.microsoft.com/en-us/nuget/what-is-nuget). Packages are typically written in the C# programming language, using the [Visual Studio](https://www.visualstudio.com/) development environment. The Bonsai installer includes project templates that make it easier to create your own package project. Once you have developed and refined your custom extensions you can package the code for installing in the Bonsai editor, or sharing with the community.
 

--- a/articles/design-guidelines.md
+++ b/articles/design-guidelines.md
@@ -1,6 +1,5 @@
 ---
 uid: design-guidelines
-title: "Design Guidelines" 
 ---
 
 # Design Guidelines

--- a/articles/editor.md
+++ b/articles/editor.md
@@ -1,6 +1,5 @@
 ---
 uid: editor
-title: "Workflow Editor"
 ---
 
 # Workflow Editor

--- a/articles/environments.md
+++ b/articles/environments.md
@@ -1,15 +1,14 @@
 ---
 uid: environments
-title: "Environments"
 ---
 
-# Bonsai Environments
+# Environments
 
-By default, Bonsai is installed system-wide and can be used to run any workflow. However, as projects grow, it is common to have to install new packages to access specific functionality, or update the version of existing packages to get the latest bug fixes and patches.
+By default, `Bonsai` is installed system-wide and can be used to run any workflow. However, as projects grow, it is common to have to install new packages to access specific functionality, or update the version of existing packages to get the latest bug fixes and patches.
 
 If you have many projects, you might notice that older projects require specific obsolete package versions which are not compatible with newer projects, resulting in setups that break when the system-wide installation gets updated since only one version of the package can be installed at any one time.
 
-Bonsai addresses these problems by supporting the creation of reproducible package environments. An environment is a self-contained, portable, installation of Bonsai that records a *snapshot* of all the packages required to run the workflows in your project. This makes it much easier to share a project with other people, or keep track of multiple separate projects in our local machine, and be assured you always have everything you need in the right place.
+`Bonsai` addresses these problems by supporting the creation of reproducible package environments. An environment is a self-contained, portable, installation of `Bonsai` that records a *snapshot* of all the packages required to run the workflows in your project. This makes it much easier to share a project with other people, or keep track of multiple separate projects in your local machine, and be assured you always have everything you need in the right place.
 
 ## Environment Basics
 The key to creating and updating environments is the `Bonsai.config` file, which keeps a record of all currently installed dependencies for a specific Bonsai setup. You can find this file in the same location of the Bonsai executable (`Bonsai.exe`). Anytime you install or update a package, Bonsai will automatically modify the config file.

--- a/articles/gallery.md
+++ b/articles/gallery.md
@@ -1,6 +1,5 @@
 ---
 uid: gallery
-title: "Bonsai Gallery"
 ---
 
 # Bonsai Gallery

--- a/articles/higher-order.md
+++ b/articles/higher-order.md
@@ -1,6 +1,5 @@
 ---
 uid: higher-order
-title: "Higher-Order Operators"
 ---
 
 # Higher-Order Operators

--- a/articles/installation.md
+++ b/articles/installation.md
@@ -1,9 +1,8 @@
 ---
 uid: installation
-title: "Installing Bonsai"
 ---
 
-# Installing Bonsai
+# Install Bonsai
 
 The Bonsai editor is currently designed to work with the .NET Framework on Windows desktop operating systems, version 7 or later. The easiest way to get started with Bonsai is by downloading the latest installer.
 

--- a/articles/observables.md
+++ b/articles/observables.md
@@ -1,6 +1,5 @@
 ---
 uid: observables
-title: "Observables"
 ---
 
 # Observables

--- a/articles/operators.md
+++ b/articles/operators.md
@@ -1,6 +1,5 @@
 ---
 uid: operators
-title: "Operators"
 ---
 
 # Operators

--- a/articles/packages.md
+++ b/articles/packages.md
@@ -1,6 +1,5 @@
 ---
 uid: packages
-title: "Package Manager"
 ---
 
 # Package Manager

--- a/articles/property-mapping.md
+++ b/articles/property-mapping.md
@@ -1,6 +1,5 @@
 ---
 uid: property-mapping
-title: "Property Mapping"
 ---
 
 # Property Mapping

--- a/articles/scripting-extensions.md
+++ b/articles/scripting-extensions.md
@@ -1,6 +1,5 @@
 ---
 uid: scripting-extensions
-title: "Scripting Extensions"
 ---
 
 # Scripting Extensions

--- a/articles/subjects.md
+++ b/articles/subjects.md
@@ -1,6 +1,5 @@
 ---
 uid: subjects
-title: "Subjects" 
 ---
 
 # Subjects

--- a/articles/toc.yml
+++ b/articles/toc.yml
@@ -1,46 +1,21 @@
-- name: Getting Started
-  href: installation.md
-  items:
-    - name: Installing Bonsai
-      href: installation.md
-    - name: Package Manager
-      href: packages.md
-    - name: Workflow Editor
-      href: editor.md
-    - name: Bonsai Gallery
-      href: gallery.md
-    - name: Environments
-      href: environments.md
+- name: Get Started
+- href: installation.md
+- href: packages.md
+- href: editor.md
+- href: gallery.md
+- href: environments.md
 - name: Language Guide
-  href: observables.md
-  items:
-    - name: Observables
-      href: observables.md
-    - name: Operators
-      href: operators.md
-    - name: Property Mapping
-      href: property-mapping.md
-    - name: Higher-Order Operators
-      href: higher-order.md
-    - name: Subjects
-      href: subjects.md
-- name: Extending Bonsai
-  href: cli.md
-  items:
-    - name: Command Line Interface
-      href: cli.md
-    - name: Scripting Extensions
-      href: scripting-extensions.md
-    - name: Creating a Package
-      href: create-package.md
-    - name: Documentation With Docfx
-      href: documentation-docfx.md
-    - name: Documentation Style Guide
-      href: documentation-style-guide.md
-- name: Design Guidelines
-  href: design-guidelines.md
-  items:
-    - name: Overview
-      href: design-guidelines.md
-    - name: Workflow Design Guidelines
-      href: workflow-guidelines.md
+- href: observables.md
+- href: operators.md
+- href: property-mapping.md
+- href: higher-order.md
+- href: subjects.md
+- name: Extend Bonsai
+- href: cli.md
+- href: scripting-extensions.md
+- href: create-package.md
+- href: documentation-docfx.md
+- href: documentation-style-guide.md
+- name: Guidelines
+- href: design-guidelines.md
+- href: workflow-guidelines.md

--- a/articles/workflow-guidelines.md
+++ b/articles/workflow-guidelines.md
@@ -1,9 +1,8 @@
 ---
 uid: workflow-guidelines
-title: "Workflow Design Guidelines" 
 ---
 
-# Workflow Design Guidelines
+# Workflow Guidelines
 
 This section offers guidelines and design patterns to consider when developing workflows for any reactive program.
 


### PR DESCRIPTION
To improve visibility of all documentation topics, this PR flattens the conceptual documentation table of contents. The number of sections is not so large right now to require collapsing hierarchies, and we can always change in the future as needed.

The version of docfx is also updated and we removed duplication of article titles throughout both metadata and TOC declarations. Minor wording tweaks were made to improve style consistency and readability.