### PR TITLE
Ensure enum values are shown in declaring order

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -23,7 +23,8 @@
       "dest": "api",
       "filter": "filter.yml",
       "disableGitFeatures": false,
-      "disableDefaultFilter": false
+      "disableDefaultFilter": false,
+      "enumSortOrder": "declaringOrder"
     }
   ],
   "build": {


### PR DESCRIPTION
The default sort order for enum values in DocFX is alphabetical order for some reason. This is unintuitive in several cases as it decouples enum values from their natural clustering in code.

This PR restores enum presentation layout to declaration order.