### PR TITLE
Use separate member pages for technical reference docs

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -22,8 +22,6 @@
       ],
       "dest": "api",
       "filter": "filter.yml",
-      "disableGitFeatures": false,
-      "disableDefaultFilter": false,
       "enumSortOrder": "declaringOrder",
       "memberLayout": "separatePages"
     }

--- a/docfx.json
+++ b/docfx.json
@@ -23,7 +23,8 @@
       "dest": "api",
       "filter": "filter.yml",
       "disableGitFeatures": false,
-      "disableDefaultFilter": false
+      "disableDefaultFilter": false,
+      "enumSortOrder": "declaringOrder"
     }
   ],
   "build": {

--- a/docfx.json
+++ b/docfx.json
@@ -24,7 +24,8 @@
       "filter": "filter.yml",
       "disableGitFeatures": false,
       "disableDefaultFilter": false,
-      "enumSortOrder": "declaringOrder"
+      "enumSortOrder": "declaringOrder",
+      "memberLayout": "separatePages"
     }
   ],
   "build": {


### PR DESCRIPTION
Currently the readability of operator docs is made more difficult by the various snippets of C# code which are scattered through the default inline version of the DocFX managed reference layout.

By using the separate member pages layout we remove all snippets and technical details, which are now replaced by a smaller table of contents providing at a glance all properties and process methods. This will be the first step towards defining a more standardized template for operator classes.