### PR TITLE
Add link to release notes on installation page

### DIFF
--- a/articles/installation.md
+++ b/articles/installation.md
@@ -13,4 +13,6 @@ The latest stable release is: **2.8.5**
 [<i class="fa fa-download"></i> Download Portable (.zip)](https://github.com/bonsai-rx/bonsai/releases/download/2.8.5/Bonsai.zip){class="btn btn-warning"}
 <!-- [/RELEASE_INFO] -->
 
+[Release Notes](https://github.com/bonsai-rx/bonsai/releases?q=prerelease%3Afalse)
+
 The installer will make sure that .NET and any other required system dependencies for running Bonsai are correctly setup in your computer.


### PR DESCRIPTION
This PR adds a link to the GitHub release page for the Bonsai core repository, with pre-releases filtered out.

This should help people decide whether to upgrade to the latest Bonsai version, especially those who don’t actively live on GitHub😄.

We previously discussed adding release notes as a menu option in the editor, which is still an option. However, linking to the release page seems like a more natural way for people to check release notes.