### PR TITLE
Add ROI editor instructions for operators with ROI properties

### DIFF
--- a/apidoc/Bonsai_Vision_Crop.md
+++ b/apidoc/Bonsai_Vision_Crop.md
@@ -1,0 +1,5 @@
+---
+uid: Bonsai.Vision.Crop
+---
+
+[!include[ROI Editor](~/articles/roi-editor.md)]

--- a/apidoc/Bonsai_Vision_CropCanvas.md
+++ b/apidoc/Bonsai_Vision_CropCanvas.md
@@ -1,0 +1,5 @@
+---
+uid: Bonsai.Vision.Drawing.CropCanvas
+---
+
+[!include[ROI Editor](~/articles/roi-editor.md)]

--- a/apidoc/Bonsai_Vision_CropPolygon.md
+++ b/apidoc/Bonsai_Vision_CropPolygon.md
@@ -1,0 +1,5 @@
+---
+uid: Bonsai.Vision.CropPolygon
+---
+
+[!include[ROI Polygonal Editor](~/articles/roi-polygon-editor.md)]

--- a/apidoc/Bonsai_Vision_GoodFeaturesToTrack.md
+++ b/apidoc/Bonsai_Vision_GoodFeaturesToTrack.md
@@ -1,0 +1,5 @@
+---
+uid: Bonsai.Vision.GoodFeaturesToTrack
+---
+
+[!include[ROI Editor](~/articles/roi-editor.md)]

--- a/apidoc/Bonsai_Vision_MaskPolygon.md
+++ b/apidoc/Bonsai_Vision_MaskPolygon.md
@@ -1,0 +1,5 @@
+---
+uid: Bonsai.Vision.MaskPolygon
+---
+
+[!include[ROI Polygonal Editor](~/articles/roi-polygon-editor.md)]

--- a/apidoc/Bonsai_Vision_RoiActivity.md
+++ b/apidoc/Bonsai_Vision_RoiActivity.md
@@ -1,0 +1,5 @@
+---
+uid: Bonsai.Vision.RoiActivity
+---
+
+[!include[ROI Polygonal Editor](~/articles/roi-polygon-editor.md)]

--- a/articles/roi-editor.md
+++ b/articles/roi-editor.md
@@ -1,6 +1,21 @@
-### ROI Editor Interface
+## Editor
 
-To open the Region of Interest (`ROI`) editor, start the workflow and click on the ellipsis button inside the `RegionOfInterest` property in the property grid.
+To open the Region of Interest (ROI) editor, start the workflow and click on the ellipsis button inside the `RegionOfInterest` property in the property grid, or double-click the operator node while holding <kbd>Ctrl</kbd>.
 
-- Create a `ROI` - Left-click in the window, drag the mouse to define the area, and release the button to complete the selection.
-- Move a `ROI` - Left-click inside the `ROI`, drag the mouse to reposition it, and release the button to finalize the move.
+### Create ROI
+
+To create a new ROI, press and hold the left mouse button anywhere in the editor window and drag the mouse to define the region of interest. Release the button to complete the selection.
+
+> [!NOTE]
+> If an ROI is already defined, pressing and holding the left mouse button *outside* the boundaries of the existing ROI will create a new ROI, and clear the previous one.
+
+### Move ROI
+
+To move an ROI, press and hold the left mouse button anywhere *inside* the existing rectangular region and drag the mouse to reposition it. Releasing the button will complete the move.
+
+### Clear ROI
+
+To clear any existing ROI, right-click anywhere in the editor window.
+
+> [!TIP]
+> Undo and redo operations are supported on any of the above actions. To undo an action press <kbd>Ctrl</kbd>+<kbd>Z</kbd> on your keyboard. To redo something you've undone, press <kbd>Ctrl</kbd>+<kbd>Y</kbd>. You can press these shortcuts multiple times if you want to undo or redo multiple steps.

--- a/articles/roi-editor.md
+++ b/articles/roi-editor.md
@@ -1,0 +1,6 @@
+### ROI Editor Interface
+
+To open the Region of Interest (`ROI`) editor, start the workflow and click on the ellipsis button inside the `RegionOfInterest` property in the property grid.
+
+- Create a `ROI` - Left-click in the window, drag the mouse to define the area, and release the button to complete the selection.
+- Move a `ROI` - Left-click inside the `ROI`, drag the mouse to reposition it, and release the button to finalize the move.

--- a/articles/roi-polygon-editor.md
+++ b/articles/roi-polygon-editor.md
@@ -1,0 +1,14 @@
+### ROI Editor Interface
+
+To open the Region of Interest (`ROI`) editor, start the workflow and click on the ellipsis button inside the `Regions` property in the property grid.
+
+- Create a `ROI` - Left-click in the window, drag the mouse to define the area, and release the button to complete the selection.
+- Move a `ROI` - Left-click inside the `ROI`, drag the mouse to reposition it, and release the button to finalize the move.
+- Delete a `ROI` - Left-click inside the `ROI` to select it, then press the `Delete` key.
+- Cycle through `ROIs` - Press the `Tab` key to switch between `ROI` selections. This is useful for locating extremely small `ROIs` that were created by mistake.
+
+To change the shape of the `ROI`:
+
+- Add control points - Double-click with the left mouse button inside the `ROI` near the line where you want to add a control point.
+- Move control points - Right-click near a control point inside the `ROI`, drag the mouse to reposition it, and release the button to complete the move.
+- Delete control points -  Double-click with the right mouse button near a control point inside the `ROI` to remove it.

--- a/articles/roi-polygon-editor.md
+++ b/articles/roi-polygon-editor.md
@@ -1,14 +1,50 @@
-### ROI Editor Interface
+## Editor
 
-To open the Region of Interest (`ROI`) editor, start the workflow and click on the ellipsis button inside the `Regions` property in the property grid.
+To open the Region of Interest (ROI) editor, start the workflow and click on the ellipsis button inside the `Regions` property in the property grid, or double-click the operator node while holding <kbd>Ctrl</kbd>.
 
-- Create a `ROI` - Left-click in the window, drag the mouse to define the area, and release the button to complete the selection.
-- Move a `ROI` - Left-click inside the `ROI`, drag the mouse to reposition it, and release the button to finalize the move.
-- Delete a `ROI` - Left-click inside the `ROI` to select it, then press the `Delete` key.
-- Cycle through `ROIs` - Press the `Tab` key to switch between `ROI` selections. This is useful for locating extremely small `ROIs` that were created by mistake.
+### Create ROI
 
-To change the shape of the `ROI`:
+To create a new ROI, press and hold the left mouse button anywhere in the editor window and drag the mouse to define a rectangular region of interest. Release the button to complete the selection. Additional ROIs can be created by pressing and holding the left mouse button in any location *outside* the boundaries of existing ROIs.
 
-- Add control points - Double-click with the left mouse button inside the `ROI` near the line where you want to add a control point.
-- Move control points - Right-click near a control point inside the `ROI`, drag the mouse to reposition it, and release the button to complete the move.
-- Delete control points -  Double-click with the right mouse button near a control point inside the `ROI` to remove it.
+> [!NOTE]
+> You can create an elliptical region of interest by holding <kbd>Shift</kbd> while dragging. You can further constrain an elliptical or rectangular region to be circular or square, respectively, by holding <kbd>Ctrl</kbd>.
+
+### Move ROI
+
+To move an ROI, press and hold the left mouse button anywhere *inside* the boundaries of an existing region and drag the mouse to reposition it. Releasing the button will complete the move.
+
+### Scale ROI
+
+To scale the shape of an ROI, press and hold the left mouse button anywhere *inside* the boundaries of an existing region and drag the mouse while holding <kbd>Shift</kbd>. Dragging the mouse away from the click will scale the region horizontally or vertically proportionally to the X and Y displacement, respectively. Releasing the button will complete the scale action.
+
+> [!NOTE]
+> You can constrain the scale to preserve the proportions of the original shape by holding <kbd>Ctrl</kbd>.
+
+### Select ROI
+
+You can select any existing ROI by clicking anywhere *inside* the boundaries of an existing region, or by pressing the <kbd>Tab</kbd> key to cycle between existing ROIs.
+
+> [!TIP]
+> Cycling selected ROIs using the <kbd>Tab</kbd> key can be very useful for locating extremely small regions which may have been created by mistake, in case they are hard to pick up by clicking.
+
+### Delete ROI
+
+To delete an ROI, first [select the ROI](#select-roi), and then press the <kbd>Del</kbd> key.
+
+### Move control point
+
+To move a control point in the polygonal ROI, press and hold the right mouse button *inside* the ROI, near the point you want to move, and drag the mouse to reposition the selected point.
+
+### Add control point
+
+To add a new control point to the polygonal ROI, double-click with the left mouse button *inside* the ROI. The new control point will be placed in the middle of the line segment which is closest to the double-click location.
+
+### Remove control point
+
+To remove a control point from the polygonal ROI, double-click with the right mouse button *inside* the ROI. The control point closest to the double-click location will be removed.
+
+> [!NOTE]
+> A minimum of three points are required to form a polygon; therefore, it is not possible to remove control points from triangular shapes.
+
+> [!TIP]
+> Undo and redo operations are supported on any of the above actions. To undo an action press <kbd>Ctrl</kbd>+<kbd>Z</kbd> on your keyboard. To redo something you've undone, press <kbd>Ctrl</kbd>+<kbd>Y</kbd>. You can press these shortcuts multiple times if you want to undo or redo multiple steps.


### PR DESCRIPTION
Fixes #134.

After reviewing the operators, it looks like there are only five operators in the current `Bonsai.Core` docs that use a ROI editor, and there are two main variants, a single ROI editor and one that accepts polygonal/multiple editors. Thus I have created two `overwrite` markdown snippets that can be included with each operator.

There may be other `ROI editors` used by operators outside of `Bonsai.Core`. For example `ScreenCaptureStream` uses an `IplImageOutputRectangleEditor` but the `Bonsai.Video` package doesn’t have a website setup yet. I will just make a note and address them as I come across them.