### PR TITLE
Update default styling of keyboard shortcuts

### DIFF
--- a/template/public/main.css
+++ b/template/public/main.css
@@ -1,4 +1,4 @@
-@import "workflow.css";
+@import "bonsai.css";
 
 /* ==========================================================================
    DESIGN GUIDELINES STYLE


### PR DESCRIPTION
The modern theme default styling for keyboard shortcuts is a little bit too high-contrast so we tweak it slightly to make it more subtle. This PR updates the submodule to the latest version, which apparently had not been done in a while, but hopefully everything should have kept consistent.